### PR TITLE
Fix UTXO loading for block zero and adjust genesis UTXO entitlement

### DIFF
--- a/x/qbtc/module/module.go
+++ b/x/qbtc/module/module.go
@@ -151,7 +151,10 @@ func (AppModule) ConsensusVersion() uint64 { return 1 }
 func (am AppModule) BeginBlock(ctx context.Context) error {
 	sdkCtx := sdk.UnwrapSDKContext(ctx)
 	utxoLoader := NewUtxoLoader(am.dataDir)
-	if err := utxoLoader.EnsureLoadUtxoFromChunkFile(sdkCtx, int(sdkCtx.BlockHeight()), am.keeper); err != nil {
+	if sdkCtx.BlockHeight() <= 0 {
+		return nil
+	}
+	if err := utxoLoader.EnsureLoadUtxoFromChunkFile(sdkCtx, int(sdkCtx.BlockHeight()-1), am.keeper); err != nil {
 		sdkCtx.Logger().Error("fail to load utxo from chunk file", "error", err)
 	}
 	return nil

--- a/x/qbtc/module/utxoloader.go
+++ b/x/qbtc/module/utxoloader.go
@@ -160,6 +160,10 @@ func (ul *UtxoLoader) LoadUtxosFromChunkFile(ctx sdk.Context, k keeper.Keeper, c
 		if err := proto.Unmarshal(utxoBytes, &utxo); err != nil {
 			return err
 		}
+		// This is the first UTXO , set it to already claimed , we need to mint 50 QBTC to start our genesis node
+		if utxo.Txid == "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b" {
+			utxo.EntitledAmount = 0
+		}
 		err = k.Utxoes.Set(ctx, utxo.GetKey(), utxo)
 		if err != nil {
 			return err


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed UTXO data processing behavior during genesis block initialization
  * Corrected initial state marking for genesis-level transaction outputs to properly reflect claim status

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->