### PR TITLE
add handler for /peerid endpoint to return peer ID and external address

### DIFF
--- a/bifrost/http.go
+++ b/bifrost/http.go
@@ -24,7 +24,7 @@ func (s *Service) handleConnectedPeers(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func (s *Service) handlePeerId(w http.ResponseWriter, r *http.Request) {
+func (s *Service) handlePeerID(w http.ResponseWriter, r *http.Request) {
 	peerID := s.network.GetHost().ID()
 	_, p, err := net.SplitHostPort(s.cfg.ListenAddr)
 	if err != nil {
@@ -48,6 +48,6 @@ func (s *Service) registerRoutes() *http.ServeMux {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/health", s.handleHealth)
 	mux.HandleFunc("/connected-peers", s.handleConnectedPeers)
-	mux.HandleFunc("/peerid", s.handlePeerId)
+	mux.HandleFunc("/peerid", s.handlePeerID)
 	return mux
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new /peerid HTTP endpoint that returns peer identification as "<peerID>@<externalIP>:<port>" in plain text. The endpoint extracts the port from the service listen address, defaults external IP to 0.0.0.0 when unset, and provides error handling with appropriate HTTP status responses and logging.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->