### PR TITLE
add limit checks

### DIFF
--- a/x/qbtc/types/msg_gov_claim_utxo.go
+++ b/x/qbtc/types/msg_gov_claim_utxo.go
@@ -13,6 +13,9 @@ func (m *MsgGovClaimUTXO) ValidateBasic() error {
 	if len(m.Utxos) == 0 {
 		return se.ErrInvalidRequest.Wrap("must provide at least one UTXO to claim")
 	}
+	if len(m.Utxos) > MaxBatchClaimUTXOs {
+		return se.ErrInvalidRequest.Wrapf("too many UTXOs in batch: %d (max %d)", len(m.Utxos), MaxBatchClaimUTXOs)
+	}
 	for _, utxo := range m.Utxos {
 		if utxo.Txid == "" {
 			return se.ErrInvalidRequest.Wrap("txid is required")

--- a/x/qbtc/types/msg_gov_claim_utxo_test.go
+++ b/x/qbtc/types/msg_gov_claim_utxo_test.go
@@ -8,6 +8,11 @@ import (
 )
 
 func TestMsgGovClaimUTXO_ValidateBasic(t *testing.T) {
+	oversizedUtxos := make([]*ClaimUTXO, MaxBatchClaimUTXOs+1)
+	for i := range oversizedUtxos {
+		oversizedUtxos[i] = &ClaimUTXO{Txid: "txid", Vout: uint32(i)}
+	}
+
 	tests := []struct {
 		name string
 		msg  MsgGovClaimUTXO
@@ -17,6 +22,7 @@ func TestMsgGovClaimUTXO_ValidateBasic(t *testing.T) {
 		{name: "no authority", msg: MsgGovClaimUTXO{Utxos: []*ClaimUTXO{{Txid: "txid", Vout: 0}}}, err: se.ErrInvalidRequest.Wrap("authority is required")},
 		{name: "no utxos", msg: MsgGovClaimUTXO{Authority: "btcq1..."}, err: se.ErrInvalidRequest.Wrap("must provide at least one UTXO to claim")},
 		{name: "no txid", msg: MsgGovClaimUTXO{Authority: "btcq1...", Utxos: []*ClaimUTXO{{Vout: 0}}}, err: se.ErrInvalidRequest.Wrap("txid is required")},
+		{name: "too many utxos", msg: MsgGovClaimUTXO{Authority: "btcq1...", Utxos: oversizedUtxos}, err: se.ErrInvalidRequest},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/x/qbtc/types/types.go
+++ b/x/qbtc/types/types.go
@@ -36,7 +36,13 @@ func GzipDeterministic(data []byte, level int) ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
+// MaxDecompressedBlockSize is the maximum allowed size of decompressed block data (50MB).
+// This prevents zip bomb DoS attacks where a small compressed payload decompresses to
+// gigabytes of data, causing all validators to OOM simultaneously.
+const MaxDecompressedBlockSize = 50 * 1024 * 1024
+
 // GzipUnzip decompresses gzip-compressed bytes and returns raw bytes.
+// The decompressed output is capped at MaxDecompressedBlockSize to prevent zip bomb attacks.
 func GzipUnzip(data []byte) ([]byte, error) {
 	if len(data) == 0 {
 		return data, nil
@@ -48,9 +54,13 @@ func GzipUnzip(data []byte) ([]byte, error) {
 	defer func() {
 		_ = r.Close()
 	}()
-	out, err := io.ReadAll(r)
+	limited := io.LimitReader(r, MaxDecompressedBlockSize+1)
+	out, err := io.ReadAll(limited)
 	if err != nil {
 		return nil, fmt.Errorf("gzip read: %w", err)
+	}
+	if len(out) > MaxDecompressedBlockSize {
+		return nil, fmt.Errorf("decompressed data exceeds maximum allowed size of %d bytes", MaxDecompressedBlockSize)
 	}
 	return out, nil
 }

--- a/x/qbtc/types/types_test.go
+++ b/x/qbtc/types/types_test.go
@@ -43,6 +43,43 @@ func TestGzipDeterministic_SameOutputAndRoundTrip(t *testing.T) {
 	}
 }
 
+func TestGzipUnzip_ExceedsMaxDecompressedSize(t *testing.T) {
+	// Create data larger than MaxDecompressedBlockSize
+	oversized := make([]byte, MaxDecompressedBlockSize+1)
+	for i := range oversized {
+		oversized[i] = 'A'
+	}
+
+	compressed, err := GzipDeterministic(oversized, gzip.BestSpeed)
+	if err != nil {
+		t.Fatalf("failed to compress oversized data: %v", err)
+	}
+
+	_, err = GzipUnzip(compressed)
+	if err == nil {
+		t.Fatal("expected error when decompressed data exceeds MaxDecompressedBlockSize, got nil")
+	}
+
+	// Data exactly at the limit should succeed
+	exact := make([]byte, MaxDecompressedBlockSize)
+	for i := range exact {
+		exact[i] = 'B'
+	}
+
+	compressedExact, err := GzipDeterministic(exact, gzip.BestSpeed)
+	if err != nil {
+		t.Fatalf("failed to compress exact-size data: %v", err)
+	}
+
+	out, err := GzipUnzip(compressedExact)
+	if err != nil {
+		t.Fatalf("expected no error for data at limit, got: %v", err)
+	}
+	if len(out) != MaxDecompressedBlockSize {
+		t.Fatalf("expected output length %d, got %d", MaxDecompressedBlockSize, len(out))
+	}
+}
+
 func TestGzipUnzip_EmptyAndInvalid(t *testing.T) {
 	t.Run("empty_input", func(t *testing.T) {
 		out, err := GzipUnzip(nil)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to prevent claiming an excessive number of UTXOs in a single batch request.
  * Implemented a 50 MB decompression size limit with error handling for oversized decompressed data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->