### PR TITLE
feat: make MsgClaimWithProof transactions gas-free

### DIFF
--- a/app/ante.go
+++ b/app/ante.go
@@ -50,6 +50,8 @@ func NewAnteHandler(options HandlerOptions) (sdk.AnteHandler, error) {
 		ebifrost.NewInjectedTxDecorator(),
 		// outermost AnteDecorator. SetUpContext must be called first
 		ante.NewSetUpContextDecorator(),
+		// free gas for MsgClaimWithProof txs — must be after SetUpContext
+		ebifrost.NewFreeClaimDecorator(),
 		ante.NewExtensionOptionsDecorator(options.ExtensionOptionChecker),
 		ante.NewValidateBasicDecorator(),
 		ante.NewTxTimeoutHeightDecorator(),

--- a/x/qbtc/ebifrost/free_claim_decorator.go
+++ b/x/qbtc/ebifrost/free_claim_decorator.go
@@ -1,0 +1,41 @@
+package ebifrost
+
+import (
+	storetypes "cosmossdk.io/store/types"
+	"github.com/btcq-org/qbtc/x/qbtc/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+type FreeClaimDecorator struct{}
+
+func NewFreeClaimDecorator() FreeClaimDecorator {
+	return FreeClaimDecorator{}
+}
+
+// AnteHandle makes MsgClaimWithProof transactions free by setting an infinite
+// gas meter and zero minimum gas prices. This must be placed after
+// SetUpContextDecorator so the gas meter override takes effect for all
+// downstream decorators (fee deduction, sig gas, etc.).
+func (fcd FreeClaimDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, next sdk.AnteHandler) (sdk.Context, error) {
+	if isClaimOnlyTx(tx) {
+		ctx = ctx.
+			WithGasMeter(storetypes.NewInfiniteGasMeter()).
+			WithMinGasPrices(sdk.DecCoins{})
+	}
+
+	return next(ctx, tx, simulate)
+}
+
+// isClaimOnlyTx returns true if the tx contains only MsgClaimWithProof messages.
+func isClaimOnlyTx(tx sdk.Tx) bool {
+	msgs := tx.GetMsgs()
+	if len(msgs) == 0 {
+		return false
+	}
+	for _, msg := range msgs {
+		if _, ok := msg.(*types.MsgClaimWithProof); !ok {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
## Summary
- Add `FreeClaimDecorator` ante handler that detects txs containing only `MsgClaimWithProof` messages
- Sets infinite gas meter and zero min gas prices so all downstream decorators (fee deduction, sig gas, tx size gas) are effectively free
- Wired into ante chain in `app/ante.go` right after `SetUpContextDecorator`
- Mixed txs (claim + other msg types) still require normal fees

## Test plan
- [ ] Verify `MsgClaimWithProof` tx succeeds with zero fees
- [ ] Verify mixed txs (claim + other msg) still require fees
- [ ] Verify other msg types are unaffected
- [ ] Spam test: confirm existing `ValidateBasic` bounds (max 50 UTXOs, max 50KB proof) mitigate free-tx abuse

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Fee-free claim processing: Proof-based claim transactions can now be submitted without incurring transaction fees. This enhancement removes financial barriers to participation and improves the overall accessibility of the claims process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->