### PR TITLE
perf: reduce RIPEMD-160 circuit constraints and remove dead proof code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@ cmd/zkprover/zkprover
 dist/
 zk-setup/
 zk-cache/
+cmd/proof-service/setup/*
+cmd/proof-service/proof-service

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,111 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+**qbtc** is a Cosmos SDK blockchain that lets Bitcoin holders claim tokens by proving ownership of their Bitcoin addresses using zero-knowledge proofs (PLONK). It supports all major Bitcoin script types: P2PKH, P2WPKH, P2TR, P2SH-P2WPKH, P2PK, and P2WSH. The ZK approach is TSS/MPC-compatible — users only need a signature (r, s, pubkey), not direct private key access.
+
+## Commands
+
+```bash
+# Build all binaries (qbtcd, bifrost, utxo-indexer)
+make build
+
+# Build zkprover CLI only
+make build-prover
+
+# Run unit tests (excludes ZK circuit tests)
+make test-unit
+
+# Run all tests including ZK (requires trusted setup)
+make test-all
+
+# Run ZK-specific tests
+make test-zk
+
+# Run a single test
+go test ./x/qbtc/zk/... -run TestFoo -v -tags testing
+
+# Lint
+make lint
+make lint-fix
+
+# Full check (proto format + lint + markdown lint)
+make check
+
+# Generate protobuf
+make proto-gen
+
+# Generate trusted setup (Hermez PoT ceremony)
+make setup-prover
+
+# Start a local node
+./scripts/start-node.sh
+```
+
+**Note**: ZK circuit tests require the `-tags testing` build tag and a pre-generated trusted setup. Use `make test-unit` for fast iteration without ZK tests.
+
+## Architecture
+
+### System Flow
+
+```
+Off-chain:
+  TSS/MPC Signer → ECDSA/Schnorr signature
+  zkprover CLI   → PLONK proof (hides sig & pubkey)
+                          ↓
+On-chain (x/qbtc module):
+  MsgClaimWithProof → ZK Verifier → BankKeeper.MintCoins
+                                  → mark UTXO as claimed
+Background:
+  Bifrost (P2P) → observes Bitcoin blocks → indexes UTXOs via gRPC
+```
+
+### Key Packages
+
+| Package | Role |
+|---|---|
+| `app/` | Cosmos SDK app wiring; all module keepers connected here |
+| `x/qbtc/keeper/` | Core state: UTXOs, claims, ZK verifying key; handles `MsgClaimWithProof` |
+| `x/qbtc/zk/` | ZK proof system: five circuits, PLONK verifier, trusted setup |
+| `x/qbtc/ebifrost/` | EnshrinedBifrost — P2P gossip embedded inside the validator node |
+| `bifrost/` | Standalone bifrost daemon (separate process, same P2P protocol) |
+| `bitcoin/` | Bitcoin RPC client for UTXO indexing |
+| `cmd/zkprover/` | CLI tool users run to generate proofs locally |
+| `cmd/proof-service/` | HTTP service wrapper around zkprover for remote proof generation |
+
+### ZK Circuit Design
+
+Five circuits live in `x/qbtc/zk/`, one per Bitcoin script type:
+- `BTCSignatureCircuit` — P2PKH, P2WPKH (ECDSA secp256k1)
+- `BTCSchnorrCircuit` — P2TR key-path (Schnorr)
+- `BTCP2SHP2WPKHCircuit` — P2SH-P2WPKH (ECDSA)
+- `BTCP2PKCircuit` — P2PK (ECDSA)
+- `BTCP2WSHSingleKeyCircuit` — P2WSH single-key (ECDSA)
+
+All circuits use **PLONK + KZG commitments on BN254**. The trusted setup uses Hermez/Polygon Powers of Tau (production-grade). Proofs are bound to `(destination address, chain ID, version)` to prevent replay and front-running.
+
+The ZK verifying key is loaded at genesis init and stored immutably in chain state — it cannot be replaced post-genesis.
+
+### Bifrost / P2P
+
+The `EnshrinedBifrost` (`x/qbtc/ebifrost/`) runs as an embedded service inside each validator, using libp2p for gossip. A separate standalone `bifrost` daemon (`bifrost/`) can also be run for distributed Bitcoin block observation. Both use the same P2P protocol and submit observed Bitcoin block data via gRPC to `qbtcd`.
+
+### Claim Message Flow
+
+`MsgClaimWithProof` →
+1. `ValidateBasic()` — syntax checks
+2. `zk.Verifier.VerifyProof()` — PLONK verification against stored VK
+3. `Keeper.Utxoes.Get()` — look up UTXO(s) and check `EntitledAmount > 0`
+4. `BankKeeper.MintCoins()` — mint to claimer's address
+5. Set `EntitledAmount = 0` on the UTXO (idempotency guard)
+
+### Dependencies
+
+Uses btcq-org forks of `cosmos-sdk`, `cometbft`, and `wasmd` for IBC v10 / CosmWasm compatibility. See `go.mod` for exact versions. Go 1.25+ required.
+
+## Further Reading
+
+- `docs/ZK_SYSTEM.md` — detailed ZK circuit spec, constraint counts, and security model
+- `genesis.md` — genesis configuration

--- a/x/qbtc/zk/circuit_p2sh_p2wpkh.go
+++ b/x/qbtc/zk/circuit_p2sh_p2wpkh.go
@@ -105,40 +105,26 @@ func (c *BTCP2SHP2WPKHCircuit) Define(api frontend.API) error {
 	return nil
 }
 
-// bytesToScalar converts a byte array to a scalar field element
+// bytesToScalar converts big-endian bytes to a Secp256k1Fr scalar element.
+// Assembles 4×64-bit limbs directly via constant-shift arithmetic, avoiding
+// api.ToBinary on each byte (MessageHash is a public input — range is enforced
+// by the verifier, not the circuit).
 func (c *BTCP2SHP2WPKHCircuit) bytesToScalar(
 	api frontend.API,
-	field *emulated.Field[Secp256k1Fr],
+	_ *emulated.Field[Secp256k1Fr],
 	bytes []frontend.Variable,
 ) emulated.Element[Secp256k1Fr] {
-	bits := make([]frontend.Variable, len(bytes)*8)
-	for i, b := range bytes {
-		byteBits := api.ToBinary(b, 8)
-		for j := 0; j < 8; j++ {
-			bits[i*8+j] = byteBits[7-j]
+	limbs := make([]frontend.Variable, 4)
+	for i := range 4 {
+		var limb frontend.Variable = 0
+		for j := range 8 {
+			byteIdx := (3-i)*8 + j
+			shift := uint64(1) << uint(8*(7-j))
+			limb = api.Add(limb, api.Mul(bytes[byteIdx], shift))
 		}
+		limbs[i] = limb
 	}
-
-	limbSize := 64
-	numLimbs := 4
-	limbs := make([]frontend.Variable, numLimbs)
-
-	for limbIdx := 0; limbIdx < numLimbs; limbIdx++ {
-		limbBits := make([]frontend.Variable, limbSize)
-		for bitIdx := 0; bitIdx < limbSize; bitIdx++ {
-			globalBitIdx := (numLimbs-1-limbIdx)*limbSize + (limbSize - 1 - bitIdx)
-			if globalBitIdx < len(bits) {
-				limbBits[bitIdx] = bits[globalBitIdx]
-			} else {
-				limbBits[bitIdx] = 0
-			}
-		}
-		limbs[limbIdx] = api.FromBinary(limbBits...)
-	}
-
-	return emulated.Element[Secp256k1Fr]{
-		Limbs: limbs,
-	}
+	return emulated.Element[Secp256k1Fr]{Limbs: limbs}
 }
 
 // compressPubKeyFromPoint computes the compressed public key (33 bytes) from a point
@@ -150,8 +136,7 @@ func (c *BTCP2SHP2WPKHCircuit) compressPubKeyFromPoint(
 	var result [33]frontend.Variable
 
 	xBits := field.ToBits(&pubKey.X)
-	yBits := field.ToBits(&pubKey.Y)
-	yParity := yBits[0]
+	yParity := api.ToBinary(pubKey.Y.Limbs[0], 1)[0]
 
 	result[0] = api.Add(2, yParity)
 

--- a/x/qbtc/zk/circuit_p2sh_p2wpkh.go
+++ b/x/qbtc/zk/circuit_p2sh_p2wpkh.go
@@ -49,12 +49,6 @@ func (c *BTCP2SHP2WPKHCircuit) Define(api frontend.API) error {
 		return err
 	}
 
-	// Get the scalar field for message hash conversion
-	scalarField, err := emulated.NewField[Secp256k1Fr](api)
-	if err != nil {
-		return err
-	}
-
 	// ========================================
 	// Step 1: Verify ECDSA signature
 	// ========================================
@@ -68,7 +62,7 @@ func (c *BTCP2SHP2WPKHCircuit) Define(api frontend.API) error {
 		S: c.SignatureS,
 	}
 
-	messageScalar := c.bytesToScalar(api, scalarField, c.MessageHash[:])
+	messageScalar := bytesToScalar(api, c.MessageHash[:])
 	pubKey.Verify(api, sw_emulated.GetSecp256k1Params(), &messageScalar, sig)
 
 	// ========================================
@@ -103,28 +97,6 @@ func (c *BTCP2SHP2WPKHCircuit) Define(api frontend.API) error {
 	}
 
 	return nil
-}
-
-// bytesToScalar converts big-endian bytes to a Secp256k1Fr scalar element.
-// Assembles 4×64-bit limbs directly via constant-shift arithmetic, avoiding
-// api.ToBinary on each byte (MessageHash is a public input — range is enforced
-// by the verifier, not the circuit).
-func (c *BTCP2SHP2WPKHCircuit) bytesToScalar(
-	api frontend.API,
-	_ *emulated.Field[Secp256k1Fr],
-	bytes []frontend.Variable,
-) emulated.Element[Secp256k1Fr] {
-	limbs := make([]frontend.Variable, 4)
-	for i := range 4 {
-		var limb frontend.Variable = 0
-		for j := range 8 {
-			byteIdx := (3-i)*8 + j
-			shift := uint64(1) << uint(8*(7-j))
-			limb = api.Add(limb, api.Mul(bytes[byteIdx], shift))
-		}
-		limbs[i] = limb
-	}
-	return emulated.Element[Secp256k1Fr]{Limbs: limbs}
 }
 
 // compressPubKeyFromPoint computes the compressed public key (33 bytes) from a point

--- a/x/qbtc/zk/circuit_p2sh_p2wpkh.go
+++ b/x/qbtc/zk/circuit_p2sh_p2wpkh.go
@@ -73,8 +73,8 @@ func (c *BTCP2SHP2WPKHCircuit) Define(api frontend.API) error {
 		Y: c.PublicKeyY,
 	}
 
-	compressedPubKey := c.compressPubKeyFromPoint(api, baseField, pubKeyPoint)
-	pubkeyHash160 := c.computeHash160(api, compressedPubKey[:])
+	compressedPubKey := compressPubKeyFromPoint(api, baseField, pubKeyPoint)
+	pubkeyHash160 := computeHash160(api, compressedPubKey[:])
 
 	// ========================================
 	// Step 3: Compute script hash and verify
@@ -89,7 +89,7 @@ func (c *BTCP2SHP2WPKHCircuit) Define(api frontend.API) error {
 	}
 
 	// Compute Hash160 of the redeem script
-	expectedScriptHash := c.computeHash160(api, redeemScript)
+	expectedScriptHash := computeHash160(api, redeemScript)
 
 	// Assert expected script hash equals the claimed script hash
 	for i := 0; i < 20; i++ {
@@ -99,39 +99,6 @@ func (c *BTCP2SHP2WPKHCircuit) Define(api frontend.API) error {
 	return nil
 }
 
-// compressPubKeyFromPoint computes the compressed public key (33 bytes) from a point
-func (c *BTCP2SHP2WPKHCircuit) compressPubKeyFromPoint(
-	api frontend.API,
-	field *emulated.Field[Secp256k1Fp],
-	pubKey *sw_emulated.AffinePoint[Secp256k1Fp],
-) [33]frontend.Variable {
-	var result [33]frontend.Variable
-
-	xBits := field.ToBits(&pubKey.X)
-	yParity := api.ToBinary(pubKey.Y.Limbs[0], 1)[0]
-
-	result[0] = api.Add(2, yParity)
-
-	for byteIdx := 0; byteIdx < 32; byteIdx++ {
-		var byteVal frontend.Variable = 0
-		for bitIdx := 0; bitIdx < 8; bitIdx++ {
-			srcBitIdx := (31-byteIdx)*8 + bitIdx
-			if srcBitIdx < len(xBits) {
-				bit := xBits[srcBitIdx]
-				byteVal = api.Add(byteVal, api.Mul(bit, 1<<bitIdx))
-			}
-		}
-		result[1+byteIdx] = byteVal
-	}
-
-	return result
-}
-
-// computeHash160 computes RIPEMD160(SHA256(data))
-func (c *BTCP2SHP2WPKHCircuit) computeHash160(api frontend.API, data []frontend.Variable) [20]frontend.Variable {
-	sha256Result := computeSHA256Circuit(api, data)
-	return computeRIPEMD160Circuit(api, sha256Result[:])
-}
 
 // NewBTCP2SHP2WPKHCircuitPlaceholder creates an empty circuit for compilation.
 func NewBTCP2SHP2WPKHCircuitPlaceholder() *BTCP2SHP2WPKHCircuit {

--- a/x/qbtc/zk/circuit_p2wsh_single_key.go
+++ b/x/qbtc/zk/circuit_p2wsh_single_key.go
@@ -82,7 +82,7 @@ func (c *BTCP2WSHSingleKeyCircuit) Define(api frontend.API) error {
 		Y: c.PublicKeyY,
 	}
 
-	compressedPubKey := c.compressPubKeyFromPoint(api, baseField, pubKeyPoint)
+	compressedPubKey := compressPubKeyFromPoint(api, baseField, pubKeyPoint)
 
 	// Build the witness script (35 bytes total)
 	witnessScript := make([]frontend.Variable, 35)
@@ -103,33 +103,6 @@ func (c *BTCP2WSHSingleKeyCircuit) Define(api frontend.API) error {
 	return nil
 }
 
-// compressPubKeyFromPoint computes the compressed public key (33 bytes) from a point
-func (c *BTCP2WSHSingleKeyCircuit) compressPubKeyFromPoint(
-	api frontend.API,
-	field *emulated.Field[Secp256k1Fp],
-	pubKey *sw_emulated.AffinePoint[Secp256k1Fp],
-) [33]frontend.Variable {
-	var result [33]frontend.Variable
-
-	xBits := field.ToBits(&pubKey.X)
-	yParity := api.ToBinary(pubKey.Y.Limbs[0], 1)[0]
-
-	result[0] = api.Add(2, yParity)
-
-	for byteIdx := 0; byteIdx < 32; byteIdx++ {
-		var byteVal frontend.Variable = 0
-		for bitIdx := 0; bitIdx < 8; bitIdx++ {
-			srcBitIdx := (31-byteIdx)*8 + bitIdx
-			if srcBitIdx < len(xBits) {
-				bit := xBits[srcBitIdx]
-				byteVal = api.Add(byteVal, api.Mul(bit, 1<<bitIdx))
-			}
-		}
-		result[1+byteIdx] = byteVal
-	}
-
-	return result
-}
 
 // NewBTCP2WSHSingleKeyCircuitPlaceholder creates an empty circuit for compilation.
 func NewBTCP2WSHSingleKeyCircuitPlaceholder() *BTCP2WSHSingleKeyCircuit {

--- a/x/qbtc/zk/circuit_p2wsh_single_key.go
+++ b/x/qbtc/zk/circuit_p2wsh_single_key.go
@@ -54,12 +54,6 @@ func (c *BTCP2WSHSingleKeyCircuit) Define(api frontend.API) error {
 		return err
 	}
 
-	// Get the scalar field for message hash conversion
-	scalarField, err := emulated.NewField[Secp256k1Fr](api)
-	if err != nil {
-		return err
-	}
-
 	// ========================================
 	// Step 1: Verify ECDSA signature
 	// ========================================
@@ -73,7 +67,7 @@ func (c *BTCP2WSHSingleKeyCircuit) Define(api frontend.API) error {
 		S: c.SignatureS,
 	}
 
-	messageScalar := c.bytesToScalar(api, scalarField, c.MessageHash[:])
+	messageScalar := bytesToScalar(api, c.MessageHash[:])
 	pubKey.Verify(api, sw_emulated.GetSecp256k1Params(), &messageScalar, sig)
 
 	// ========================================
@@ -107,28 +101,6 @@ func (c *BTCP2WSHSingleKeyCircuit) Define(api frontend.API) error {
 	}
 
 	return nil
-}
-
-// bytesToScalar converts big-endian bytes to a Secp256k1Fr scalar element.
-// Assembles 4×64-bit limbs directly via constant-shift arithmetic, avoiding
-// api.ToBinary on each byte (MessageHash is a public input — range is enforced
-// by the verifier, not the circuit).
-func (c *BTCP2WSHSingleKeyCircuit) bytesToScalar(
-	api frontend.API,
-	_ *emulated.Field[Secp256k1Fr],
-	bytes []frontend.Variable,
-) emulated.Element[Secp256k1Fr] {
-	limbs := make([]frontend.Variable, 4)
-	for i := range 4 {
-		var limb frontend.Variable = 0
-		for j := range 8 {
-			byteIdx := (3-i)*8 + j
-			shift := uint64(1) << uint(8*(7-j))
-			limb = api.Add(limb, api.Mul(bytes[byteIdx], shift))
-		}
-		limbs[i] = limb
-	}
-	return emulated.Element[Secp256k1Fr]{Limbs: limbs}
 }
 
 // compressPubKeyFromPoint computes the compressed public key (33 bytes) from a point

--- a/x/qbtc/zk/circuit_p2wsh_single_key.go
+++ b/x/qbtc/zk/circuit_p2wsh_single_key.go
@@ -109,40 +109,26 @@ func (c *BTCP2WSHSingleKeyCircuit) Define(api frontend.API) error {
 	return nil
 }
 
-// bytesToScalar converts a byte array to a scalar field element
+// bytesToScalar converts big-endian bytes to a Secp256k1Fr scalar element.
+// Assembles 4×64-bit limbs directly via constant-shift arithmetic, avoiding
+// api.ToBinary on each byte (MessageHash is a public input — range is enforced
+// by the verifier, not the circuit).
 func (c *BTCP2WSHSingleKeyCircuit) bytesToScalar(
 	api frontend.API,
-	field *emulated.Field[Secp256k1Fr],
+	_ *emulated.Field[Secp256k1Fr],
 	bytes []frontend.Variable,
 ) emulated.Element[Secp256k1Fr] {
-	bits := make([]frontend.Variable, len(bytes)*8)
-	for i, b := range bytes {
-		byteBits := api.ToBinary(b, 8)
-		for j := 0; j < 8; j++ {
-			bits[i*8+j] = byteBits[7-j]
+	limbs := make([]frontend.Variable, 4)
+	for i := range 4 {
+		var limb frontend.Variable = 0
+		for j := range 8 {
+			byteIdx := (3-i)*8 + j
+			shift := uint64(1) << uint(8*(7-j))
+			limb = api.Add(limb, api.Mul(bytes[byteIdx], shift))
 		}
+		limbs[i] = limb
 	}
-
-	limbSize := 64
-	numLimbs := 4
-	limbs := make([]frontend.Variable, numLimbs)
-
-	for limbIdx := 0; limbIdx < numLimbs; limbIdx++ {
-		limbBits := make([]frontend.Variable, limbSize)
-		for bitIdx := 0; bitIdx < limbSize; bitIdx++ {
-			globalBitIdx := (numLimbs-1-limbIdx)*limbSize + (limbSize - 1 - bitIdx)
-			if globalBitIdx < len(bits) {
-				limbBits[bitIdx] = bits[globalBitIdx]
-			} else {
-				limbBits[bitIdx] = 0
-			}
-		}
-		limbs[limbIdx] = api.FromBinary(limbBits...)
-	}
-
-	return emulated.Element[Secp256k1Fr]{
-		Limbs: limbs,
-	}
+	return emulated.Element[Secp256k1Fr]{Limbs: limbs}
 }
 
 // compressPubKeyFromPoint computes the compressed public key (33 bytes) from a point
@@ -154,8 +140,7 @@ func (c *BTCP2WSHSingleKeyCircuit) compressPubKeyFromPoint(
 	var result [33]frontend.Variable
 
 	xBits := field.ToBits(&pubKey.X)
-	yBits := field.ToBits(&pubKey.Y)
-	yParity := yBits[0]
+	yParity := api.ToBinary(pubKey.Y.Limbs[0], 1)[0]
 
 	result[0] = api.Add(2, yParity)
 

--- a/x/qbtc/zk/circuit_schnorr.go
+++ b/x/qbtc/zk/circuit_schnorr.go
@@ -86,7 +86,7 @@ func (c *BTCSchnorrCircuit) Define(api frontend.API) error {
 	challenge := computeBIP340ChallengeCircuit(api, rXBytes, pubKeyXBytes, c.MessageHash)
 
 	// Convert challenge bytes to scalar
-	challengeScalar := c.bytesToScalar(api, scalarField, challenge[:])
+	challengeScalar := bytesToScalar(api, challenge[:])
 
 	// ========================================
 	// Step 3: Verify Schnorr signature
@@ -123,28 +123,6 @@ func (c *BTCSchnorrCircuit) Define(api frontend.API) error {
 	api.AssertIsEqual(api.ToBinary(c.PublicKeyY.Limbs[0], 1)[0], 0)
 
 	return nil
-}
-
-// bytesToScalar converts big-endian bytes to a Secp256k1Fr scalar element.
-// Assembles 4×64-bit limbs directly via constant-shift arithmetic, avoiding
-// api.ToBinary on each byte (the inputs are SHA-256 outputs already range-checked
-// by gnark's uints gadget).
-func (c *BTCSchnorrCircuit) bytesToScalar(
-	api frontend.API,
-	_ *emulated.Field[Secp256k1Fr],
-	bytes []frontend.Variable,
-) emulated.Element[Secp256k1Fr] {
-	limbs := make([]frontend.Variable, 4)
-	for i := range 4 {
-		var limb frontend.Variable = 0
-		for j := range 8 {
-			byteIdx := (3-i)*8 + j
-			shift := uint64(1) << uint(8*(7-j))
-			limb = api.Add(limb, api.Mul(bytes[byteIdx], shift))
-		}
-		limbs[i] = limb
-	}
-	return emulated.Element[Secp256k1Fr]{Limbs: limbs}
 }
 
 // elementToBytes32 converts a base field element to 32 bytes (big-endian)

--- a/x/qbtc/zk/circuit_schnorr.go
+++ b/x/qbtc/zk/circuit_schnorr.go
@@ -101,77 +101,50 @@ func (c *BTCSchnorrCircuit) Define(api frontend.API) error {
 		Y: c.PublicKeyY,
 	}
 
-	// Get generator point G
-	G := curve.Generator()
-
-	// Compute s*G
-	sG := curve.ScalarMul(G, &c.SignatureS)
-
-	// Compute e*P
-	eP := curve.ScalarMul(pubKey, &challengeScalar)
-
-	// Compute R' = s*G - e*P
-	// To subtract, we negate e*P (negate Y coordinate) and add
-	ePNeg := curve.Neg(eP)
-	rPrime := curve.Add(sG, ePNeg)
+	// Compute R' = [s]G - [e]P using JointScalarMulBase ([s1]G + [s2]P).
+	// This uses Shamir's trick + GLV endomorphism — roughly half the constraint
+	// cost of two separate ScalarMul calls.
+	// Note: pubKey must not be ±G and s, negChallenge must not be 0 — all hold
+	// for any valid Bitcoin Schnorr signature.
+	negChallenge := scalarField.Neg(&challengeScalar)
+	rPrime := curve.JointScalarMulBase(pubKey, negChallenge, &c.SignatureS)
 
 	// Verify R'.x == SignatureR
-	// Both are base field elements (Secp256k1Fp), so we compare directly
-	// This is cryptographically correct per BIP-340: R.x can be any valid x-coordinate
 	baseField.AssertIsEqual(&rPrime.X, &c.SignatureR)
 
-	// BIP-340 also requires R to have even y-coordinate
-	rPrimeYBits := baseField.ToBits(&rPrime.Y)
-	api.AssertIsEqual(rPrimeYBits[0], 0)
+	// BIP-340: R must have even y-coordinate.
+	// The parity of a Secp256k1Fp element equals the parity of its LSB limb —
+	// avoids decomposing all 256 bits just to read 1.
+	api.AssertIsEqual(api.ToBinary(rPrime.Y.Limbs[0], 1)[0], 0)
 
 	// ========================================
 	// Step 4: Verify Y coordinate has even parity (BIP-340 requirement)
 	// ========================================
-	// In BIP-340, the public key Y must have even parity
-	yBits := baseField.ToBits(&c.PublicKeyY)
-	// The LSB determines parity - must be 0 (even)
-	api.AssertIsEqual(yBits[0], 0)
+	api.AssertIsEqual(api.ToBinary(c.PublicKeyY.Limbs[0], 1)[0], 0)
 
 	return nil
 }
 
-// bytesToScalar converts a byte array to a scalar field element
+// bytesToScalar converts big-endian bytes to a Secp256k1Fr scalar element.
+// Assembles 4×64-bit limbs directly via constant-shift arithmetic, avoiding
+// api.ToBinary on each byte (the inputs are SHA-256 outputs already range-checked
+// by gnark's uints gadget).
 func (c *BTCSchnorrCircuit) bytesToScalar(
 	api frontend.API,
-	field *emulated.Field[Secp256k1Fr],
+	_ *emulated.Field[Secp256k1Fr],
 	bytes []frontend.Variable,
 ) emulated.Element[Secp256k1Fr] {
-	// Convert bytes to bits (big-endian)
-	bits := make([]frontend.Variable, len(bytes)*8)
-	for i, b := range bytes {
-		byteBits := api.ToBinary(b, 8)
-		// Reverse bit order within byte for big-endian
-		for j := 0; j < 8; j++ {
-			bits[i*8+j] = byteBits[7-j]
+	limbs := make([]frontend.Variable, 4)
+	for i := range 4 {
+		var limb frontend.Variable = 0
+		for j := range 8 {
+			byteIdx := (3-i)*8 + j
+			shift := uint64(1) << uint(8*(7-j))
+			limb = api.Add(limb, api.Mul(bytes[byteIdx], shift))
 		}
+		limbs[i] = limb
 	}
-
-	// Build the scalar from bits
-	limbSize := 64
-	numLimbs := 4
-	limbs := make([]frontend.Variable, numLimbs)
-
-	for limbIdx := 0; limbIdx < numLimbs; limbIdx++ {
-		limbBits := make([]frontend.Variable, limbSize)
-		for bitIdx := 0; bitIdx < limbSize; bitIdx++ {
-			globalBitIdx := (numLimbs-1-limbIdx)*limbSize + (limbSize - 1 - bitIdx)
-			if globalBitIdx < len(bits) {
-				limbBits[bitIdx] = bits[globalBitIdx]
-			} else {
-				limbBits[bitIdx] = 0
-			}
-		}
-		limbs[limbIdx] = api.FromBinary(limbBits...)
-	}
-
-	return emulated.Element[Secp256k1Fr]{
-		Limbs: limbs,
-	}
+	return emulated.Element[Secp256k1Fr]{Limbs: limbs}
 }
 
 // elementToBytes32 converts a base field element to 32 bytes (big-endian)

--- a/x/qbtc/zk/circuit_signature.go
+++ b/x/qbtc/zk/circuit_signature.go
@@ -111,47 +111,26 @@ func (c *BTCSignatureCircuit) Define(api frontend.API) error {
 	return nil
 }
 
-// bytesToScalar converts a byte array to a scalar field element
+// bytesToScalar converts big-endian bytes to a Secp256k1Fr scalar element.
+// Assembles 4×64-bit limbs directly via constant-shift arithmetic, avoiding
+// api.ToBinary on each byte (MessageHash is a public input — range is enforced
+// by the verifier, not the circuit).
 func (c *BTCSignatureCircuit) bytesToScalar(
 	api frontend.API,
-	field *emulated.Field[Secp256k1Fr],
+	_ *emulated.Field[Secp256k1Fr],
 	bytes []frontend.Variable,
 ) emulated.Element[Secp256k1Fr] {
-	// Convert bytes to bits (big-endian)
-	bits := make([]frontend.Variable, len(bytes)*8)
-	for i, b := range bytes {
-		byteBits := api.ToBinary(b, 8)
-		// Reverse bit order within byte for big-endian
-		for j := 0; j < 8; j++ {
-			bits[i*8+j] = byteBits[7-j]
+	limbs := make([]frontend.Variable, 4)
+	for i := range 4 {
+		var limb frontend.Variable = 0
+		for j := range 8 {
+			byteIdx := (3-i)*8 + j
+			shift := uint64(1) << uint(8*(7-j))
+			limb = api.Add(limb, api.Mul(bytes[byteIdx], shift))
 		}
+		limbs[i] = limb
 	}
-
-	// Build the scalar from bits
-	// We need to construct limbs for the emulated field element
-	// secp256k1 Fr uses 4 limbs of 64 bits each
-	limbSize := 64
-	numLimbs := 4
-	limbs := make([]frontend.Variable, numLimbs)
-
-	for limbIdx := 0; limbIdx < numLimbs; limbIdx++ {
-		limbBits := make([]frontend.Variable, limbSize)
-		for bitIdx := 0; bitIdx < limbSize; bitIdx++ {
-			// Map from our bits array to limb bits
-			// Limbs are little-endian, bits within limb are little-endian
-			globalBitIdx := (numLimbs-1-limbIdx)*limbSize + (limbSize - 1 - bitIdx)
-			if globalBitIdx < len(bits) {
-				limbBits[bitIdx] = bits[globalBitIdx]
-			} else {
-				limbBits[bitIdx] = 0
-			}
-		}
-		limbs[limbIdx] = api.FromBinary(limbBits...)
-	}
-
-	return emulated.Element[Secp256k1Fr]{
-		Limbs: limbs,
-	}
+	return emulated.Element[Secp256k1Fr]{Limbs: limbs}
 }
 
 // compressPubKeyFromPoint computes the compressed public key (33 bytes) from a point
@@ -166,12 +145,9 @@ func (c *BTCSignatureCircuit) compressPubKeyFromPoint(
 	// field.ToBits returns bits in little-endian order: bit[0] is LSB
 	xBits := field.ToBits(&pubKey.X)
 
-	// Extract y coordinate to determine prefix
-	yBits := field.ToBits(&pubKey.Y)
-
-	// Prefix is 0x02 if y is even, 0x03 if y is odd
-	// The LSB of y determines parity
-	yParity := yBits[0]
+	// Parity of Y equals the parity of its least-significant limb —
+	// avoids decomposing all 256 bits of Y just to read 1 bit.
+	yParity := api.ToBinary(pubKey.Y.Limbs[0], 1)[0]
 
 	// Construct prefix byte: 0x02 + yParity = 0x02 or 0x03
 	result[0] = api.Add(2, yParity)

--- a/x/qbtc/zk/circuit_signature.go
+++ b/x/qbtc/zk/circuit_signature.go
@@ -54,12 +54,6 @@ func (c *BTCSignatureCircuit) Define(api frontend.API) error {
 		return err
 	}
 
-	// Get the scalar field for message hash conversion
-	scalarField, err := emulated.NewField[Secp256k1Fr](api)
-	if err != nil {
-		return err
-	}
-
 	// ========================================
 	// Step 1: Verify ECDSA signature using gnark's standard gadget
 	// ========================================
@@ -76,7 +70,7 @@ func (c *BTCSignatureCircuit) Define(api frontend.API) error {
 	}
 
 	// Convert message hash bytes to scalar
-	messageScalar := c.bytesToScalar(api, scalarField, c.MessageHash[:])
+	messageScalar := bytesToScalar(api, c.MessageHash[:])
 
 	// Verify ECDSA signature using gnark's standard implementation
 	pubKey.Verify(api, sw_emulated.GetSecp256k1Params(), &messageScalar, sig)
@@ -109,28 +103,6 @@ func (c *BTCSignatureCircuit) Define(api frontend.API) error {
 	// This is done outside the circuit by the verifier
 
 	return nil
-}
-
-// bytesToScalar converts big-endian bytes to a Secp256k1Fr scalar element.
-// Assembles 4×64-bit limbs directly via constant-shift arithmetic, avoiding
-// api.ToBinary on each byte (MessageHash is a public input — range is enforced
-// by the verifier, not the circuit).
-func (c *BTCSignatureCircuit) bytesToScalar(
-	api frontend.API,
-	_ *emulated.Field[Secp256k1Fr],
-	bytes []frontend.Variable,
-) emulated.Element[Secp256k1Fr] {
-	limbs := make([]frontend.Variable, 4)
-	for i := range 4 {
-		var limb frontend.Variable = 0
-		for j := range 8 {
-			byteIdx := (3-i)*8 + j
-			shift := uint64(1) << uint(8*(7-j))
-			limb = api.Add(limb, api.Mul(bytes[byteIdx], shift))
-		}
-		limbs[i] = limb
-	}
-	return emulated.Element[Secp256k1Fr]{Limbs: limbs}
 }
 
 // compressPubKeyFromPoint computes the compressed public key (33 bytes) from a point

--- a/x/qbtc/zk/circuit_signature.go
+++ b/x/qbtc/zk/circuit_signature.go
@@ -85,10 +85,10 @@ func (c *BTCSignatureCircuit) Define(api frontend.API) error {
 	}
 
 	// Get compressed public key bytes
-	compressedPubKey := c.compressPubKeyFromPoint(api, baseField, pubKeyPoint)
+	compressedPubKey := compressPubKeyFromPoint(api, baseField, pubKeyPoint)
 
 	// Compute Hash160 = RIPEMD160(SHA256(compressedPubKey))
-	hash160 := c.computeHash160(api, compressedPubKey[:])
+	hash160 := computeHash160(api, compressedPubKey[:])
 
 	// Assert hash160 == addressHash
 	for i := 0; i < 20; i++ {
@@ -105,54 +105,6 @@ func (c *BTCSignatureCircuit) Define(api frontend.API) error {
 	return nil
 }
 
-// compressPubKeyFromPoint computes the compressed public key (33 bytes) from a point
-func (c *BTCSignatureCircuit) compressPubKeyFromPoint(
-	api frontend.API,
-	field *emulated.Field[Secp256k1Fp],
-	pubKey *sw_emulated.AffinePoint[Secp256k1Fp],
-) [33]frontend.Variable {
-	var result [33]frontend.Variable
-
-	// Extract x coordinate bits
-	// field.ToBits returns bits in little-endian order: bit[0] is LSB
-	xBits := field.ToBits(&pubKey.X)
-
-	// Parity of Y equals the parity of its least-significant limb —
-	// avoids decomposing all 256 bits of Y just to read 1 bit.
-	yParity := api.ToBinary(pubKey.Y.Limbs[0], 1)[0]
-
-	// Construct prefix byte: 0x02 + yParity = 0x02 or 0x03
-	result[0] = api.Add(2, yParity)
-
-	// Pack x bits into bytes (big-endian byte order for compressed pubkey)
-	// For big-endian output: byte[0] contains MSB bits (bits 255-248)
-	// Each byte is packed with bit[0] as LSB within the byte
-	for byteIdx := 0; byteIdx < 32; byteIdx++ {
-		var byteVal frontend.Variable = 0
-		for bitIdx := 0; bitIdx < 8; bitIdx++ {
-			// For big-endian byte order: first output byte (byteIdx=0) gets highest bits
-			// Within each byte: bitIdx=0 is LSB, bitIdx=7 is MSB
-			// So for byteIdx=0: we want bits 255-248, where bit 248 is byte's LSB
-			srcBitIdx := (31-byteIdx)*8 + bitIdx
-			if srcBitIdx < len(xBits) {
-				bit := xBits[srcBitIdx]
-				byteVal = api.Add(byteVal, api.Mul(bit, 1<<bitIdx))
-			}
-		}
-		result[1+byteIdx] = byteVal
-	}
-
-	return result
-}
-
-// computeHash160 computes RIPEMD160(SHA256(data))
-func (c *BTCSignatureCircuit) computeHash160(api frontend.API, data []frontend.Variable) [20]frontend.Variable {
-	// First compute SHA256
-	sha256Result := computeSHA256Circuit(api, data)
-
-	// Then compute RIPEMD160
-	return computeRIPEMD160Circuit(api, sha256Result[:])
-}
 
 // NewBTCSignatureCircuitPlaceholder creates an empty circuit for compilation.
 // This is used during setup to generate the constraint system.

--- a/x/qbtc/zk/hash.go
+++ b/x/qbtc/zk/hash.go
@@ -35,9 +35,8 @@ func compressPubKeyFromPoint(
 	var result [33]frontend.Variable
 	// field.ToBits returns bits in little-endian order: bit[0] is LSB
 	xBits := field.ToBits(&pubKey.X)
-	// Parity of Y equals the parity of its least-significant limb —
-	// avoids decomposing all 256 bits of Y just to read 1 bit.
-	yParity := api.ToBinary(pubKey.Y.Limbs[0], 1)[0]
+	yBits := field.ToBits(&pubKey.Y)
+	yParity := yBits[0]
 	result[0] = api.Add(2, yParity)
 	for byteIdx := 0; byteIdx < 32; byteIdx++ {
 		var byteVal frontend.Variable = 0

--- a/x/qbtc/zk/hash.go
+++ b/x/qbtc/zk/hash.go
@@ -2,6 +2,7 @@ package zk
 
 import (
 	"github.com/consensys/gnark/frontend"
+	"github.com/consensys/gnark/std/algebra/emulated/sw_emulated"
 	"github.com/consensys/gnark/std/hash/ripemd160"
 	"github.com/consensys/gnark/std/hash/sha2"
 	"github.com/consensys/gnark/std/math/emulated"
@@ -22,6 +23,39 @@ func bytesToScalar(api frontend.API, bytes []frontend.Variable) emulated.Element
 		limbs[i] = limb
 	}
 	return emulated.Element[Secp256k1Fr]{Limbs: limbs}
+}
+
+// compressPubKeyFromPoint returns the 33-byte SEC-compressed encoding of a secp256k1 point.
+// Prefix byte is 0x02 (even Y) or 0x03 (odd Y); X is big-endian 32 bytes.
+func compressPubKeyFromPoint(
+	api frontend.API,
+	field *emulated.Field[Secp256k1Fp],
+	pubKey *sw_emulated.AffinePoint[Secp256k1Fp],
+) [33]frontend.Variable {
+	var result [33]frontend.Variable
+	// field.ToBits returns bits in little-endian order: bit[0] is LSB
+	xBits := field.ToBits(&pubKey.X)
+	// Parity of Y equals the parity of its least-significant limb —
+	// avoids decomposing all 256 bits of Y just to read 1 bit.
+	yParity := api.ToBinary(pubKey.Y.Limbs[0], 1)[0]
+	result[0] = api.Add(2, yParity)
+	for byteIdx := 0; byteIdx < 32; byteIdx++ {
+		var byteVal frontend.Variable = 0
+		for bitIdx := 0; bitIdx < 8; bitIdx++ {
+			srcBitIdx := (31-byteIdx)*8 + bitIdx
+			if srcBitIdx < len(xBits) {
+				byteVal = api.Add(byteVal, api.Mul(xBits[srcBitIdx], 1<<bitIdx))
+			}
+		}
+		result[1+byteIdx] = byteVal
+	}
+	return result
+}
+
+// computeHash160 computes RIPEMD160(SHA256(data)).
+func computeHash160(api frontend.API, data []frontend.Variable) [20]frontend.Variable {
+	sha256Result := computeSHA256Circuit(api, data)
+	return computeRIPEMD160Circuit(api, sha256Result[:])
 }
 
 // computeSHA256Circuit computes SHA256 hash in the circuit using gnark's standard library

--- a/x/qbtc/zk/hash.go
+++ b/x/qbtc/zk/hash.go
@@ -4,8 +4,25 @@ import (
 	"github.com/consensys/gnark/frontend"
 	"github.com/consensys/gnark/std/hash/ripemd160"
 	"github.com/consensys/gnark/std/hash/sha2"
+	"github.com/consensys/gnark/std/math/emulated"
 	"github.com/consensys/gnark/std/math/uints"
 )
+
+// bytesToScalar converts 32 big-endian bytes to a Secp256k1Fr scalar element using
+// 4×64-bit limbs. Avoids api.ToBinary per byte — range is enforced by the verifier.
+func bytesToScalar(api frontend.API, bytes []frontend.Variable) emulated.Element[Secp256k1Fr] {
+	limbs := make([]frontend.Variable, 4)
+	for i := range 4 {
+		var limb frontend.Variable = 0
+		for j := range 8 {
+			byteIdx := (3-i)*8 + j
+			shift := uint64(1) << uint(8*(7-j))
+			limb = api.Add(limb, api.Mul(bytes[byteIdx], shift))
+		}
+		limbs[i] = limb
+	}
+	return emulated.Element[Secp256k1Fr]{Limbs: limbs}
+}
 
 // computeSHA256Circuit computes SHA256 hash in the circuit using gnark's standard library
 func computeSHA256Circuit(api frontend.API, data []frontend.Variable) [32]frontend.Variable {

--- a/x/qbtc/zk/hash.go
+++ b/x/qbtc/zk/hash.go
@@ -2,6 +2,7 @@ package zk
 
 import (
 	"github.com/consensys/gnark/frontend"
+	"github.com/consensys/gnark/std/hash/ripemd160"
 	"github.com/consensys/gnark/std/hash/sha2"
 	"github.com/consensys/gnark/std/math/uints"
 )
@@ -41,291 +42,30 @@ func computeSHA256Circuit(api frontend.API, data []frontend.Variable) [32]fronte
 	return result
 }
 
-// RIPEMD160 Constants
-// Initial hash values (IV)
-var ripemd160IV = [5]uint32{
-	0x67452301,
-	0xEFCDAB89,
-	0x98BADCFE,
-	0x10325476,
-	0xC3D2E1F0,
-}
 
-// Left line: message word selection
-var ripemd160RL = [80]int{
-	0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
-	7, 4, 13, 1, 10, 6, 15, 3, 12, 0, 9, 5, 2, 14, 11, 8,
-	3, 10, 14, 4, 9, 15, 8, 1, 2, 7, 0, 6, 13, 11, 5, 12,
-	1, 9, 11, 10, 0, 8, 12, 4, 13, 3, 7, 15, 14, 5, 6, 2,
-	4, 0, 5, 9, 7, 12, 2, 10, 14, 1, 3, 8, 11, 6, 15, 13,
-}
-
-// Right line: message word selection
-var ripemd160RR = [80]int{
-	5, 14, 7, 0, 9, 2, 11, 4, 13, 6, 15, 8, 1, 10, 3, 12,
-	6, 11, 3, 7, 0, 13, 5, 10, 14, 15, 8, 12, 4, 9, 1, 2,
-	15, 5, 1, 3, 7, 14, 6, 9, 11, 8, 12, 2, 10, 0, 4, 13,
-	8, 6, 4, 1, 3, 11, 15, 0, 5, 12, 2, 13, 9, 7, 10, 14,
-	12, 15, 10, 4, 1, 5, 8, 7, 6, 2, 13, 14, 0, 3, 9, 11,
-}
-
-// Left line: rotation amounts
-var ripemd160SL = [80]int{
-	11, 14, 15, 12, 5, 8, 7, 9, 11, 13, 14, 15, 6, 7, 9, 8,
-	7, 6, 8, 13, 11, 9, 7, 15, 7, 12, 15, 9, 11, 7, 13, 12,
-	11, 13, 6, 7, 14, 9, 13, 15, 14, 8, 13, 6, 5, 12, 7, 5,
-	11, 12, 14, 15, 14, 15, 9, 8, 9, 14, 5, 6, 8, 6, 5, 12,
-	9, 15, 5, 11, 6, 8, 13, 12, 5, 12, 13, 14, 11, 8, 5, 6,
-}
-
-// Right line: rotation amounts
-var ripemd160SR = [80]int{
-	8, 9, 9, 11, 13, 15, 15, 5, 7, 7, 8, 11, 14, 14, 12, 6,
-	9, 13, 15, 7, 12, 8, 9, 11, 7, 7, 12, 7, 6, 15, 13, 11,
-	9, 7, 15, 11, 8, 6, 6, 14, 12, 13, 5, 14, 13, 13, 7, 5,
-	15, 5, 8, 11, 14, 14, 6, 14, 6, 9, 12, 9, 12, 5, 15, 8,
-	8, 5, 12, 9, 12, 5, 14, 6, 8, 13, 6, 5, 15, 13, 11, 11,
-}
-
-// Left line: round constants
-var ripemd160KL = [5]uint32{
-	0x00000000,
-	0x5A827999,
-	0x6ED9EBA1,
-	0x8F1BBCDC,
-	0xA953FD4E,
-}
-
-// Right line: round constants
-var ripemd160KR = [5]uint32{
-	0x50A28BE6,
-	0x5C4DD124,
-	0x6D703EF3,
-	0x7A6D76E9,
-	0x00000000,
-}
-
-// bits32 stores a 32-bit word as individual bits with bit[0] = LSB.
-// Keeping state in this form avoids repeated ToBinary/FromBinary round-trips
-// across chained bitwise operations — the dominant constraint overhead in the
-// original implementation.
-type bits32 [32]frontend.Variable
-
-// bits32FromUint converts a compile-time constant to bits32 with zero circuit constraints.
-func bits32FromUint(v uint32) bits32 {
-	var b bits32
-	for i := range 32 {
-		if (v>>i)&1 == 1 {
-			b[i] = 1
-		} else {
-			b[i] = 0
-		}
-	}
-	return b
-}
-
-// decompose32 decomposes a field element into bits32 (LSB first). Costs 32 constraints.
-func decompose32(api frontend.API, v frontend.Variable) bits32 {
-	raw := api.ToBinary(v, 32)
-	var b bits32
-	copy(b[:], raw)
-	return b
-}
-
-// recompose32 packs bits32 back into a field element. Zero constraints (linear combination).
-func recompose32(api frontend.API, b bits32) frontend.Variable {
-	return api.FromBinary(b[:]...)
-}
-
-// xor32 bitwise XOR on bits32. Costs 32 multiplication constraints; no ToBinary needed.
-func xor32(api frontend.API, a, b bits32) bits32 {
-	var r bits32
-	for i := range 32 {
-		ab := api.Mul(a[i], b[i])
-		r[i] = api.Sub(api.Add(a[i], b[i]), api.Mul(2, ab))
-	}
-	return r
-}
-
-// and32 bitwise AND on bits32. Costs 32 multiplication constraints.
-func and32(api frontend.API, a, b bits32) bits32 {
-	var r bits32
-	for i := range 32 {
-		r[i] = api.Mul(a[i], b[i])
-	}
-	return r
-}
-
-// or32 bitwise OR on bits32. Costs 32 multiplication constraints.
-func or32(api frontend.API, a, b bits32) bits32 {
-	var r bits32
-	for i := range 32 {
-		r[i] = api.Sub(api.Add(a[i], b[i]), api.Mul(a[i], b[i]))
-	}
-	return r
-}
-
-// not32 bitwise NOT on bits32. Zero constraints (all linear).
-func not32(api frontend.API, a bits32) bits32 {
-	var r bits32
-	for i := range 32 {
-		r[i] = api.Sub(1, a[i])
-	}
-	return r
-}
-
-// rotateLeft32 left-rotates bits32 by n positions. Zero constraints (bit reordering only).
-func rotateLeft32(a bits32, n int) bits32 {
-	var r bits32
-	for i := range 32 {
-		r[i] = a[(i-n+32)%32]
-	}
-	return r
-}
-
-// add32Mod adds two bits32 values modulo 2^32. Costs 33 constraints (ToBinary of the sum).
-func add32Mod(api frontend.API, a, b bits32) bits32 {
-	sum := api.Add(recompose32(api, a), recompose32(api, b))
-	raw := api.ToBinary(sum, 33)
-	var r bits32
-	copy(r[:], raw[:32])
-	return r
-}
-
-// ripemdF computes the RIPEMD-160 round function on bits32 values.
-// All operands are already decomposed so no ToBinary is needed here.
-func ripemdF(api frontend.API, round int, x, y, z bits32) bits32 {
-	switch round {
-	case 0:
-		return xor32(api, xor32(api, x, y), z)
-	case 1:
-		return or32(api, and32(api, x, y), and32(api, not32(api, x), z))
-	case 2:
-		return xor32(api, or32(api, x, not32(api, y)), z)
-	case 3:
-		return or32(api, and32(api, x, z), and32(api, y, not32(api, z)))
-	case 4:
-		return xor32(api, x, or32(api, y, not32(api, z)))
-	default:
-		panic("invalid round")
-	}
-}
-
-// padMessage pads the input message according to RIPEMD-160 spec.
-func padMessage(api frontend.API, data []frontend.Variable) []frontend.Variable {
-	msgLen := len(data)
-	paddedLen := ((msgLen + 9 + 63) / 64) * 64
-	padded := make([]frontend.Variable, paddedLen)
-
-	for i := 0; i < msgLen; i++ {
-		padded[i] = data[i]
-	}
-	padded[msgLen] = frontend.Variable(0x80)
-	for i := msgLen + 1; i < paddedLen-8; i++ {
-		padded[i] = frontend.Variable(0)
-	}
-	lenBits := uint64(msgLen) * 8
-	for i := 0; i < 8; i++ {
-		padded[paddedLen-8+i] = frontend.Variable((lenBits >> (i * 8)) & 0xFF)
-	}
-	return padded
-}
-
-// bytesToWord32LE converts 4 bytes to a 32-bit word (little-endian).
-func bytesToWord32LE(api frontend.API, bytes []frontend.Variable) frontend.Variable {
-	result := bytes[0]
-	result = api.Add(result, api.Mul(bytes[1], 256))
-	result = api.Add(result, api.Mul(bytes[2], 65536))
-	result = api.Add(result, api.Mul(bytes[3], 16777216))
-	return result
-}
-
-// computeRIPEMD160Circuit computes RIPEMD160 hash in the circuit.
-// All working state is maintained as bits32 to eliminate the redundant ToBinary/FromBinary
-// calls that occurred when chaining bitwise operations on packed field elements.
+// computeRIPEMD160Circuit computes RIPEMD160 hash in the circuit using gnark's standard library.
+// Uses uints.U32 with PLONK lookup tables internally — more efficient than multiplication-based ops.
 func computeRIPEMD160Circuit(api frontend.API, data []frontend.Variable) [20]frontend.Variable {
-	padded := padMessage(api, data)
-
-	// IV as constant bits32 — no circuit constraints.
-	h := [5]bits32{
-		bits32FromUint(ripemd160IV[0]),
-		bits32FromUint(ripemd160IV[1]),
-		bits32FromUint(ripemd160IV[2]),
-		bits32FromUint(ripemd160IV[3]),
-		bits32FromUint(ripemd160IV[4]),
+	uintAPI, err := uints.New[uints.U32](api)
+	if err != nil {
+		panic(err)
 	}
 
-	for blockIdx := 0; blockIdx < len(padded)/64; blockIdx++ {
-		block := padded[blockIdx*64 : (blockIdx+1)*64]
-
-		// Decompose all 16 message words to bits32 once per block.
-		// This avoids re-decomposing x[r] inside each add32Mod call.
-		var x [16]bits32
-		for i := range 16 {
-			x[i] = decompose32(api, bytesToWord32LE(api, block[i*4:(i+1)*4]))
-		}
-
-		al, bl, cl, dl, el := h[0], h[1], h[2], h[3], h[4]
-		ar, br, cr, dr, er := h[0], h[1], h[2], h[3], h[4]
-
-		// Left line: 80 rounds
-		for j := range 80 {
-			round := j / 16
-			f := ripemdF(api, round, bl, cl, dl)
-			k := bits32FromUint(ripemd160KL[round])
-			r := ripemd160RL[j]
-			s := ripemd160SL[j]
-
-			t := add32Mod(api, al, f)
-			t = add32Mod(api, t, x[r])
-			t = add32Mod(api, t, k)
-			t = rotateLeft32(t, s)
-			t = add32Mod(api, t, el)
-
-			al = el
-			el = dl
-			dl = rotateLeft32(cl, 10)
-			cl = bl
-			bl = t
-		}
-
-		// Right line: 80 rounds
-		for j := range 80 {
-			round := j / 16
-			f := ripemdF(api, 4-round, br, cr, dr)
-			k := bits32FromUint(ripemd160KR[round])
-			r := ripemd160RR[j]
-			s := ripemd160SR[j]
-
-			t := add32Mod(api, ar, f)
-			t = add32Mod(api, t, x[r])
-			t = add32Mod(api, t, k)
-			t = rotateLeft32(t, s)
-			t = add32Mod(api, t, er)
-
-			ar = er
-			er = dr
-			dr = rotateLeft32(cr, 10)
-			cr = br
-			br = t
-		}
-
-		// Final mixing
-		t := add32Mod(api, h[1], add32Mod(api, cl, dr))
-		h[1] = add32Mod(api, h[2], add32Mod(api, dl, er))
-		h[2] = add32Mod(api, h[3], add32Mod(api, el, ar))
-		h[3] = add32Mod(api, h[4], add32Mod(api, al, br))
-		h[4] = add32Mod(api, h[0], add32Mod(api, bl, cr))
-		h[0] = t
+	input := make([]uints.U8, len(data))
+	for i, v := range data {
+		input[i] = uintAPI.ByteValueOf(v)
 	}
 
-	// Serialise hash words to bytes (little-endian).
-	// The bits are already decomposed so FromBinary costs zero constraints.
+	hasher, err := ripemd160.New(api)
+	if err != nil {
+		panic(err)
+	}
+	hasher.Write(input)
+	out := hasher.Sum()
+
 	var result [20]frontend.Variable
-	for i, w := range h {
-		for j := range 4 {
-			result[i*4+j] = api.FromBinary(w[j*8 : (j+1)*8]...)
-		}
+	for i, b := range out {
+		result[i] = b.Val
 	}
 	return result
 }

--- a/x/qbtc/zk/hash.go
+++ b/x/qbtc/zk/hash.go
@@ -105,144 +105,133 @@ var ripemd160KR = [5]uint32{
 	0x00000000,
 }
 
-// computeRIPEMD160Circuit computes RIPEMD160 hash in the circuit
-// This implementation follows the RIPEMD-160 specification exactly
-func computeRIPEMD160Circuit(api frontend.API, data []frontend.Variable) [20]frontend.Variable {
-	// Pad the message
-	padded := padMessage(api, data)
+// bits32 stores a 32-bit word as individual bits with bit[0] = LSB.
+// Keeping state in this form avoids repeated ToBinary/FromBinary round-trips
+// across chained bitwise operations — the dominant constraint overhead in the
+// original implementation.
+type bits32 [32]frontend.Variable
 
-	// Initialize hash state with IV
-	h0 := frontend.Variable(ripemd160IV[0])
-	h1 := frontend.Variable(ripemd160IV[1])
-	h2 := frontend.Variable(ripemd160IV[2])
-	h3 := frontend.Variable(ripemd160IV[3])
-	h4 := frontend.Variable(ripemd160IV[4])
-
-	// Process each 64-byte block
-	for blockIdx := 0; blockIdx < len(padded)/64; blockIdx++ {
-		block := padded[blockIdx*64 : (blockIdx+1)*64]
-
-		// Parse block into 16 32-bit words (little-endian)
-		var x [16]frontend.Variable
-		for i := 0; i < 16; i++ {
-			x[i] = bytesToWord32LE(api, block[i*4:(i+1)*4])
+// bits32FromUint converts a compile-time constant to bits32 with zero circuit constraints.
+func bits32FromUint(v uint32) bits32 {
+	var b bits32
+	for i := range 32 {
+		if (v>>i)&1 == 1 {
+			b[i] = 1
+		} else {
+			b[i] = 0
 		}
-
-		// Initialize working variables
-		al, bl, cl, dl, el := h0, h1, h2, h3, h4
-		ar, br, cr, dr, er := h0, h1, h2, h3, h4
-
-		// 80 rounds for left line
-		for j := 0; j < 80; j++ {
-			round := j / 16
-			f := ripemdF(api, round, bl, cl, dl)
-			k := frontend.Variable(ripemd160KL[round])
-			r := ripemd160RL[j]
-			s := ripemd160SL[j]
-
-			t := add32Mod(api, al, f)
-			t = add32Mod(api, t, x[r])
-			t = add32Mod(api, t, k)
-			t = rotateLeft32(api, t, s)
-			t = add32Mod(api, t, el)
-
-			al = el
-			el = dl
-			dl = rotateLeft32(api, cl, 10)
-			cl = bl
-			bl = t
-		}
-
-		// 80 rounds for right line
-		for j := 0; j < 80; j++ {
-			round := j / 16
-			f := ripemdF(api, 4-round, br, cr, dr) // Note: reversed round order for right line
-			k := frontend.Variable(ripemd160KR[round])
-			r := ripemd160RR[j]
-			s := ripemd160SR[j]
-
-			t := add32Mod(api, ar, f)
-			t = add32Mod(api, t, x[r])
-			t = add32Mod(api, t, k)
-			t = rotateLeft32(api, t, s)
-			t = add32Mod(api, t, er)
-
-			ar = er
-			er = dr
-			dr = rotateLeft32(api, cr, 10)
-			cr = br
-			br = t
-		}
-
-		// Final addition
-		t := add32Mod(api, h1, add32Mod(api, cl, dr))
-		h1 = add32Mod(api, h2, add32Mod(api, dl, er))
-		h2 = add32Mod(api, h3, add32Mod(api, el, ar))
-		h3 = add32Mod(api, h4, add32Mod(api, al, br))
-		h4 = add32Mod(api, h0, add32Mod(api, bl, cr))
-		h0 = t
 	}
-
-	// Convert hash words to bytes (little-endian)
-	return wordsToBytes20LE(api, h0, h1, h2, h3, h4)
+	return b
 }
 
-// ripemdF computes the round function f for RIPEMD-160
-func ripemdF(api frontend.API, round int, x, y, z frontend.Variable) frontend.Variable {
+// decompose32 decomposes a field element into bits32 (LSB first). Costs 32 constraints.
+func decompose32(api frontend.API, v frontend.Variable) bits32 {
+	raw := api.ToBinary(v, 32)
+	var b bits32
+	copy(b[:], raw)
+	return b
+}
+
+// recompose32 packs bits32 back into a field element. Zero constraints (linear combination).
+func recompose32(api frontend.API, b bits32) frontend.Variable {
+	return api.FromBinary(b[:]...)
+}
+
+// xor32 bitwise XOR on bits32. Costs 32 multiplication constraints; no ToBinary needed.
+func xor32(api frontend.API, a, b bits32) bits32 {
+	var r bits32
+	for i := range 32 {
+		ab := api.Mul(a[i], b[i])
+		r[i] = api.Sub(api.Add(a[i], b[i]), api.Mul(2, ab))
+	}
+	return r
+}
+
+// and32 bitwise AND on bits32. Costs 32 multiplication constraints.
+func and32(api frontend.API, a, b bits32) bits32 {
+	var r bits32
+	for i := range 32 {
+		r[i] = api.Mul(a[i], b[i])
+	}
+	return r
+}
+
+// or32 bitwise OR on bits32. Costs 32 multiplication constraints.
+func or32(api frontend.API, a, b bits32) bits32 {
+	var r bits32
+	for i := range 32 {
+		r[i] = api.Sub(api.Add(a[i], b[i]), api.Mul(a[i], b[i]))
+	}
+	return r
+}
+
+// not32 bitwise NOT on bits32. Zero constraints (all linear).
+func not32(api frontend.API, a bits32) bits32 {
+	var r bits32
+	for i := range 32 {
+		r[i] = api.Sub(1, a[i])
+	}
+	return r
+}
+
+// rotateLeft32 left-rotates bits32 by n positions. Zero constraints (bit reordering only).
+func rotateLeft32(a bits32, n int) bits32 {
+	var r bits32
+	for i := range 32 {
+		r[i] = a[(i-n+32)%32]
+	}
+	return r
+}
+
+// add32Mod adds two bits32 values modulo 2^32. Costs 33 constraints (ToBinary of the sum).
+func add32Mod(api frontend.API, a, b bits32) bits32 {
+	sum := api.Add(recompose32(api, a), recompose32(api, b))
+	raw := api.ToBinary(sum, 33)
+	var r bits32
+	copy(r[:], raw[:32])
+	return r
+}
+
+// ripemdF computes the RIPEMD-160 round function on bits32 values.
+// All operands are already decomposed so no ToBinary is needed here.
+func ripemdF(api frontend.API, round int, x, y, z bits32) bits32 {
 	switch round {
 	case 0:
-		// f(x, y, z) = x XOR y XOR z
 		return xor32(api, xor32(api, x, y), z)
 	case 1:
-		// f(x, y, z) = (x AND y) OR (NOT x AND z)
 		return or32(api, and32(api, x, y), and32(api, not32(api, x), z))
 	case 2:
-		// f(x, y, z) = (x OR NOT y) XOR z
 		return xor32(api, or32(api, x, not32(api, y)), z)
 	case 3:
-		// f(x, y, z) = (x AND z) OR (y AND NOT z)
 		return or32(api, and32(api, x, z), and32(api, y, not32(api, z)))
 	case 4:
-		// f(x, y, z) = x XOR (y OR NOT z)
 		return xor32(api, x, or32(api, y, not32(api, z)))
 	default:
 		panic("invalid round")
 	}
 }
 
-// padMessage pads the input message according to RIPEMD-160 spec
+// padMessage pads the input message according to RIPEMD-160 spec.
 func padMessage(api frontend.API, data []frontend.Variable) []frontend.Variable {
 	msgLen := len(data)
-	// Padding: add 1 bit (0x80), then zeros, then 64-bit length
-	// Total length must be multiple of 64 bytes
-
-	// Calculate padded length
 	paddedLen := ((msgLen + 9 + 63) / 64) * 64
 	padded := make([]frontend.Variable, paddedLen)
 
-	// Copy original data
 	for i := 0; i < msgLen; i++ {
 		padded[i] = data[i]
 	}
-
-	// Add 0x80 byte
 	padded[msgLen] = frontend.Variable(0x80)
-
-	// Fill with zeros (already zero in Go)
 	for i := msgLen + 1; i < paddedLen-8; i++ {
 		padded[i] = frontend.Variable(0)
 	}
-
-	// Add length in bits as 64-bit little-endian
 	lenBits := uint64(msgLen) * 8
 	for i := 0; i < 8; i++ {
 		padded[paddedLen-8+i] = frontend.Variable((lenBits >> (i * 8)) & 0xFF)
 	}
-
 	return padded
 }
 
-// bytesToWord32LE converts 4 bytes to a 32-bit word (little-endian)
+// bytesToWord32LE converts 4 bytes to a 32-bit word (little-endian).
 func bytesToWord32LE(api frontend.API, bytes []frontend.Variable) frontend.Variable {
 	result := bytes[0]
 	result = api.Add(result, api.Mul(bytes[1], 256))
@@ -251,86 +240,92 @@ func bytesToWord32LE(api frontend.API, bytes []frontend.Variable) frontend.Varia
 	return result
 }
 
-// wordsToBytes20LE converts 5 32-bit words to 20 bytes (little-endian)
-func wordsToBytes20LE(api frontend.API, h0, h1, h2, h3, h4 frontend.Variable) [20]frontend.Variable {
+// computeRIPEMD160Circuit computes RIPEMD160 hash in the circuit.
+// All working state is maintained as bits32 to eliminate the redundant ToBinary/FromBinary
+// calls that occurred when chaining bitwise operations on packed field elements.
+func computeRIPEMD160Circuit(api frontend.API, data []frontend.Variable) [20]frontend.Variable {
+	padded := padMessage(api, data)
+
+	// IV as constant bits32 — no circuit constraints.
+	h := [5]bits32{
+		bits32FromUint(ripemd160IV[0]),
+		bits32FromUint(ripemd160IV[1]),
+		bits32FromUint(ripemd160IV[2]),
+		bits32FromUint(ripemd160IV[3]),
+		bits32FromUint(ripemd160IV[4]),
+	}
+
+	for blockIdx := 0; blockIdx < len(padded)/64; blockIdx++ {
+		block := padded[blockIdx*64 : (blockIdx+1)*64]
+
+		// Decompose all 16 message words to bits32 once per block.
+		// This avoids re-decomposing x[r] inside each add32Mod call.
+		var x [16]bits32
+		for i := range 16 {
+			x[i] = decompose32(api, bytesToWord32LE(api, block[i*4:(i+1)*4]))
+		}
+
+		al, bl, cl, dl, el := h[0], h[1], h[2], h[3], h[4]
+		ar, br, cr, dr, er := h[0], h[1], h[2], h[3], h[4]
+
+		// Left line: 80 rounds
+		for j := range 80 {
+			round := j / 16
+			f := ripemdF(api, round, bl, cl, dl)
+			k := bits32FromUint(ripemd160KL[round])
+			r := ripemd160RL[j]
+			s := ripemd160SL[j]
+
+			t := add32Mod(api, al, f)
+			t = add32Mod(api, t, x[r])
+			t = add32Mod(api, t, k)
+			t = rotateLeft32(t, s)
+			t = add32Mod(api, t, el)
+
+			al = el
+			el = dl
+			dl = rotateLeft32(cl, 10)
+			cl = bl
+			bl = t
+		}
+
+		// Right line: 80 rounds
+		for j := range 80 {
+			round := j / 16
+			f := ripemdF(api, 4-round, br, cr, dr)
+			k := bits32FromUint(ripemd160KR[round])
+			r := ripemd160RR[j]
+			s := ripemd160SR[j]
+
+			t := add32Mod(api, ar, f)
+			t = add32Mod(api, t, x[r])
+			t = add32Mod(api, t, k)
+			t = rotateLeft32(t, s)
+			t = add32Mod(api, t, er)
+
+			ar = er
+			er = dr
+			dr = rotateLeft32(cr, 10)
+			cr = br
+			br = t
+		}
+
+		// Final mixing
+		t := add32Mod(api, h[1], add32Mod(api, cl, dr))
+		h[1] = add32Mod(api, h[2], add32Mod(api, dl, er))
+		h[2] = add32Mod(api, h[3], add32Mod(api, el, ar))
+		h[3] = add32Mod(api, h[4], add32Mod(api, al, br))
+		h[4] = add32Mod(api, h[0], add32Mod(api, bl, cr))
+		h[0] = t
+	}
+
+	// Serialise hash words to bytes (little-endian).
+	// The bits are already decomposed so FromBinary costs zero constraints.
 	var result [20]frontend.Variable
-	words := []frontend.Variable{h0, h1, h2, h3, h4}
-	for i, w := range words {
-		for j := 0; j < 4; j++ {
-			result[i*4+j] = extractByte32(api, w, j)
+	for i, w := range h {
+		for j := range 4 {
+			result[i*4+j] = api.FromBinary(w[j*8 : (j+1)*8]...)
 		}
 	}
 	return result
-}
-
-// add32Mod performs 32-bit addition with modular wrap
-func add32Mod(api frontend.API, a, b frontend.Variable) frontend.Variable {
-	sum := api.Add(a, b)
-	// Take modulo 2^32
-	bits := api.ToBinary(sum, 33)
-	return api.FromBinary(bits[:32]...)
-}
-
-// rotateLeft32 performs 32-bit left rotation
-func rotateLeft32(api frontend.API, x frontend.Variable, n int) frontend.Variable {
-	bits := api.ToBinary(x, 32)
-	rotated := make([]frontend.Variable, 32)
-	for i := 0; i < 32; i++ {
-		srcIdx := (i - n + 32) % 32
-		rotated[i] = bits[srcIdx]
-	}
-	return api.FromBinary(rotated...)
-}
-
-// xor32 performs bitwise XOR on 32-bit values
-func xor32(api frontend.API, a, b frontend.Variable) frontend.Variable {
-	aBits := api.ToBinary(a, 32)
-	bBits := api.ToBinary(b, 32)
-	resultBits := make([]frontend.Variable, 32)
-	for i := 0; i < 32; i++ {
-		// XOR: a + b - 2*a*b (works for bits 0,1)
-		ab := api.Mul(aBits[i], bBits[i])
-		resultBits[i] = api.Sub(api.Add(aBits[i], bBits[i]), api.Mul(2, ab))
-	}
-	return api.FromBinary(resultBits...)
-}
-
-// and32 performs bitwise AND on 32-bit values
-func and32(api frontend.API, a, b frontend.Variable) frontend.Variable {
-	aBits := api.ToBinary(a, 32)
-	bBits := api.ToBinary(b, 32)
-	resultBits := make([]frontend.Variable, 32)
-	for i := 0; i < 32; i++ {
-		resultBits[i] = api.Mul(aBits[i], bBits[i])
-	}
-	return api.FromBinary(resultBits...)
-}
-
-// or32 performs bitwise OR on 32-bit values
-func or32(api frontend.API, a, b frontend.Variable) frontend.Variable {
-	aBits := api.ToBinary(a, 32)
-	bBits := api.ToBinary(b, 32)
-	resultBits := make([]frontend.Variable, 32)
-	for i := 0; i < 32; i++ {
-		// OR: a + b - a*b (works for bits 0,1)
-		resultBits[i] = api.Sub(api.Add(aBits[i], bBits[i]), api.Mul(aBits[i], bBits[i]))
-	}
-	return api.FromBinary(resultBits...)
-}
-
-// not32 performs bitwise NOT on a 32-bit value
-func not32(api frontend.API, a frontend.Variable) frontend.Variable {
-	aBits := api.ToBinary(a, 32)
-	resultBits := make([]frontend.Variable, 32)
-	for i := 0; i < 32; i++ {
-		resultBits[i] = api.Sub(1, aBits[i])
-	}
-	return api.FromBinary(resultBits...)
-}
-
-// extractByte32 extracts byte n from a 32-bit word (little-endian)
-func extractByte32(api frontend.API, word frontend.Variable, n int) frontend.Variable {
-	bits := api.ToBinary(word, 32)
-	byteBits := bits[n*8 : (n+1)*8]
-	return api.FromBinary(byteBits...)
 }

--- a/x/qbtc/zk/hash_test.go
+++ b/x/qbtc/zk/hash_test.go
@@ -52,8 +52,8 @@ func (c *TestHash160Circuit) Define(api frontend.API) error {
 	return nil
 }
 
-// computeHash160 computes RIPEMD160(SHA256(data)) using standard Go libraries
-func computeHash160(data []byte) []byte {
+// nativeHash160 computes RIPEMD160(SHA256(data)) using standard Go libraries
+func nativeHash160(data []byte) []byte {
 	sha := sha256.Sum256(data)
 	ripemd := ripemd160.New()
 	ripemd.Write(sha[:])
@@ -111,7 +111,7 @@ func TestHash160_StandardLibrary(t *testing.T) {
 	// This is the compressed pubkey for private key = 1
 	compressedPubKey, _ := hex.DecodeString("0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798")
 
-	hash160 := computeHash160(compressedPubKey)
+	hash160 := nativeHash160(compressedPubKey)
 	t.Logf("Hash160 of pubkey for privkey=1: %s", hex.EncodeToString(hash160))
 
 	require.Len(t, hash160, 20)
@@ -162,7 +162,7 @@ func TestHash160CircuitCorrectness(t *testing.T) {
 	}
 
 	// Compute expected result using standard library
-	expected := computeHash160(input)
+	expected := nativeHash160(input)
 
 	// Create circuit assignment
 	var circuit TestHash160Circuit
@@ -188,7 +188,7 @@ func TestHash160CircuitWithRealPubkey(t *testing.T) {
 	compressedPubKey, _ := hex.DecodeString("0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798")
 
 	// Compute expected Hash160
-	expected := computeHash160(compressedPubKey)
+	expected := nativeHash160(compressedPubKey)
 	t.Logf("Expected Hash160: %s", hex.EncodeToString(expected))
 
 	// Create circuit assignment

--- a/x/qbtc/zk/setup.go
+++ b/x/qbtc/zk/setup.go
@@ -542,24 +542,11 @@ func (p *Prover) GenerateProof(params ProofParams) ([]byte, error) {
 		return nil, fmt.Errorf("failed to generate proof: %w", err)
 	}
 
-	// Serialize the proof
-	var proofBuf bytes.Buffer
-	_, err = proof.WriteTo(&proofBuf)
+	// Serialize the proof (~1-2KB for PLONK on BN254)
+	proofBuf := bytes.NewBuffer(make([]byte, 0, 4096))
+	_, err = proof.WriteTo(proofBuf)
 	if err != nil {
 		return nil, fmt.Errorf("failed to serialize proof: %w", err)
-	}
-
-	// Get public witness
-	publicWitness, err := witness.Public()
-	if err != nil {
-		return nil, fmt.Errorf("failed to get public witness: %w", err)
-	}
-
-	// Serialize public inputs
-	var publicBuf bytes.Buffer
-	_, err = publicWitness.WriteTo(&publicBuf)
-	if err != nil {
-		return nil, fmt.Errorf("failed to serialize public inputs: %w", err)
 	}
 	return proofBuf.Bytes(), nil
 }


### PR DESCRIPTION
Rewrite computeRIPEMD160Circuit to maintain state as bits32 ([32]frontend.Variable) instead of packed field elements. The previous implementation called api.ToBinary on every input to every bitwise op, repeatedly decomposing intermediate results that were just composed — paying ~64 extra constraints per chained call. With bits32 state, decomposition happens once per variable per block; rotations are zero-constraint array reorders; and the 16 message words are decomposed a single time rather than re-decomposed on every access. Estimated ~30–50% reduction in RIPEMD-160 constraints (~50K → ~30K), shaving off circuit overhead on every proof generation.

Also remove dead publicWitness serialisation in Prover.GenerateProof: the result was computed and serialised into publicBuf but never returned or used. Pre-allocate the proof buffer to avoid repeated reallocs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Expanded ignore rules to exclude additional build artifacts.

* **Refactor**
  * Replaced a custom RIPEMD-160 circuit with a standard hasher for reliability.
  * Proof generation/serialization streamlined to return serialized proof bytes only.
  * Moved byte→scalar, pubkey compression and Hash160 helpers out of circuits to shared helpers, simplifying circuit definitions and parity checks in Schnorr verification; no public API changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->