### PR TITLE
fix: use relative URL for openapi.json in Swagger UI template

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -9,8 +9,9 @@ import (
 )
 
 const (
-	apiFile   = "/static/openapi.json"
-	indexFile = "template/index.tpl"
+	apiFile         = "/static/openapi.json"
+	apiFileRelative = "static/openapi.json"
+	indexFile       = "template/index.tpl"
 )
 
 //go:embed static
@@ -34,7 +35,7 @@ func handler(title string) http.HandlerFunc {
 			URL   string
 		}{
 			title,
-			apiFile,
+			apiFileRelative,
 		})
 	}
 }


### PR DESCRIPTION
## Summary

- The Swagger UI page was configured with an absolute URL (`/static/openapi.json`) for the OpenAPI spec
- When served behind a reverse proxy at a subpath (e.g. `https://api.vultisig.com/qbtc-rpc/`), Swagger UI fetches from the domain root (`https://api.vultisig.com/static/openapi.json`) instead of the subpath, resulting in a fetch error: `undefined /static/openapi.json`
- Fix: introduce `apiFileRelative = "static/openapi.json"` (no leading slash) and pass it to the template — the route registration stays at `/static/openapi.json` which gorilla/mux requires

## Test plan

- [x] Start `qbtcd` locally with API enabled (`enable = true` in `app.toml`)
- [x] Open `http://localhost:1317/` — Swagger UI should load without errors
- [x] Confirm the rendered template contains `url: "static/openapi.json"` (relative, no leading slash)
- [x] Confirm `GET /static/openapi.json` still returns 200

Closes #138

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed API documentation console to properly load the OpenAPI specification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->