### PR TITLE
fix(ante): pre-create signer accounts for first-time claimers (#142)

### DIFF
--- a/app/ante.go
+++ b/app/ante.go
@@ -21,6 +21,10 @@ type HandlerOptions struct {
 	QbtcKeeper            *keeper.Keeper
 	WasmConfig            *wasmtypes.WasmConfig
 	TXCounterStoreService corestoretypes.KVStoreService
+	// AuthKeeper is a superset of ante.AccountKeeper that also exposes
+	// NewAccountWithAddress, required by FreeClaimDecorator to pre-create
+	// first-time claimers' accounts.
+	AuthKeeper ebifrost.AccountKeeper
 }
 
 // NewAnteHandler returns an AnteHandler that checks and increments sequence
@@ -29,6 +33,10 @@ type HandlerOptions struct {
 func NewAnteHandler(options HandlerOptions) (sdk.AnteHandler, error) {
 	if options.AccountKeeper == nil {
 		return nil, errors.New("account keeper is required for ante builder")
+	}
+
+	if options.AuthKeeper == nil {
+		return nil, errors.New("auth keeper is required for ante builder")
 	}
 
 	if options.BankKeeper == nil {
@@ -51,7 +59,7 @@ func NewAnteHandler(options HandlerOptions) (sdk.AnteHandler, error) {
 		// outermost AnteDecorator. SetUpContext must be called first
 		ante.NewSetUpContextDecorator(),
 		// free gas for MsgClaimWithProof txs — must be after SetUpContext
-		ebifrost.NewFreeClaimDecorator(),
+		ebifrost.NewFreeClaimDecorator(options.AuthKeeper),
 		ante.NewExtensionOptionsDecorator(options.ExtensionOptionChecker),
 		ante.NewValidateBasicDecorator(),
 		ante.NewTxTimeoutHeightDecorator(),
@@ -85,6 +93,7 @@ func (app *App) setAnteHandler(txConfig client.TxConfig) {
 			QbtcKeeper:            app.QbtcKeeper,
 			WasmConfig:            &wasmConfig,
 			TXCounterStoreService: runtime.NewKVStoreService(app.GetKey(wasmtypes.StoreKey)), // TX counter uses main store, not transient
+			AuthKeeper:            app.AuthKeeper,
 		},
 	)
 	if err != nil {

--- a/x/qbtc/ebifrost/free_claim_decorator.go
+++ b/x/qbtc/ebifrost/free_claim_decorator.go
@@ -1,29 +1,87 @@
 package ebifrost
 
 import (
+	"context"
+
+	errorsmod "cosmossdk.io/errors"
 	storetypes "cosmossdk.io/store/types"
 	"github.com/btcq-org/qbtc/x/qbtc/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	authsigning "github.com/cosmos/cosmos-sdk/x/auth/signing"
 )
 
-type FreeClaimDecorator struct{}
+// AccountKeeper is the subset of x/auth's AccountKeeper the decorator needs to
+// pre-create signer accounts for first-time claimers.
+type AccountKeeper interface {
+	GetAccount(ctx context.Context, addr sdk.AccAddress) sdk.AccountI
+	NewAccountWithAddress(ctx context.Context, addr sdk.AccAddress) sdk.AccountI
+	SetAccount(ctx context.Context, acc sdk.AccountI)
+}
 
-func NewFreeClaimDecorator() FreeClaimDecorator {
-	return FreeClaimDecorator{}
+type FreeClaimDecorator struct {
+	ak AccountKeeper
+}
+
+func NewFreeClaimDecorator(ak AccountKeeper) FreeClaimDecorator {
+	return FreeClaimDecorator{ak: ak}
 }
 
 // AnteHandle makes MsgClaimWithProof transactions free by setting an infinite
-// gas meter and zero minimum gas prices. This must be placed after
-// SetUpContextDecorator so the gas meter override takes effect for all
-// downstream decorators (fee deduction, sig gas, etc.).
+// gas meter and zero minimum gas prices. It also pre-creates the signer
+// account when absent, because every claim is by definition a first-time
+// on-chain interaction — without this, downstream DeductFee / SetPubKey /
+// SigVerification decorators reject the tx with "account does not exist".
+// Must be placed after SetUpContextDecorator so the gas meter override takes
+// effect for all downstream decorators.
 func (fcd FreeClaimDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, next sdk.AnteHandler) (sdk.Context, error) {
-	if isClaimOnlyTx(tx) {
-		ctx = ctx.
-			WithGasMeter(storetypes.NewInfiniteGasMeter()).
-			WithMinGasPrices(sdk.DecCoins{})
+	if !isClaimOnlyTx(tx) {
+		return next(ctx, tx, simulate)
+	}
+
+	ctx = ctx.
+		WithGasMeter(storetypes.NewInfiniteGasMeter()).
+		WithMinGasPrices(sdk.DecCoins{})
+
+	if err := fcd.ensureSignerAccounts(ctx, tx); err != nil {
+		return ctx, err
 	}
 
 	return next(ctx, tx, simulate)
+}
+
+// ensureSignerAccounts creates on-chain accounts for the tx's signers and fee
+// payer when they don't exist yet. Safe because FreeClaimDecorator only fires
+// on claim-only txs, which are gated by the ZK proof and signature verified
+// later in the chain.
+func (fcd FreeClaimDecorator) ensureSignerAccounts(ctx sdk.Context, tx sdk.Tx) error {
+	sigTx, ok := tx.(authsigning.SigVerifiableTx)
+	if !ok {
+		return errorsmod.Wrap(sdkerrors.ErrTxDecode, "claim tx must be a SigVerifiableTx")
+	}
+
+	signers, err := sigTx.GetSigners()
+	if err != nil {
+		return err
+	}
+	for _, signer := range signers {
+		fcd.createAccountIfMissing(ctx, signer)
+	}
+
+	if feeTx, ok := tx.(sdk.FeeTx); ok {
+		if payer := feeTx.FeePayer(); len(payer) > 0 {
+			fcd.createAccountIfMissing(ctx, payer)
+		}
+	}
+
+	return nil
+}
+
+func (fcd FreeClaimDecorator) createAccountIfMissing(ctx sdk.Context, addr sdk.AccAddress) {
+	if fcd.ak.GetAccount(ctx, addr) != nil {
+		return
+	}
+	fcd.ak.SetAccount(ctx, fcd.ak.NewAccountWithAddress(ctx, addr))
 }
 
 // isClaimOnlyTx returns true if the tx contains only MsgClaimWithProof messages.

--- a/x/qbtc/ebifrost/free_claim_decorator.go
+++ b/x/qbtc/ebifrost/free_claim_decorator.go
@@ -39,6 +39,17 @@ func (fcd FreeClaimDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bo
 		return next(ctx, tx, simulate)
 	}
 
+	// A free-claim tx must carry exactly one MsgClaimWithProof. Bundling many
+	// lets an attacker pre-create an account per message at zero cost: each
+	// proof only needs to pass ValidateBasic's structural checks, and ante
+	// writes persist even when the handler later rejects the proofs. Batch
+	// claiming across UTXOs is supported inside a single MsgClaimWithProof
+	// via Utxos, so this limit doesn't block any legitimate flow.
+	if len(tx.GetMsgs()) != 1 {
+		return ctx, errorsmod.Wrap(sdkerrors.ErrInvalidRequest,
+			"free-claim tx must contain exactly one MsgClaimWithProof")
+	}
+
 	ctx = ctx.
 		WithGasMeter(storetypes.NewInfiniteGasMeter()).
 		WithMinGasPrices(sdk.DecCoins{})

--- a/x/qbtc/ebifrost/free_claim_decorator_test.go
+++ b/x/qbtc/ebifrost/free_claim_decorator_test.go
@@ -109,6 +109,36 @@ func TestFreeClaimDecorator_PreservesExistingAccount(t *testing.T) {
 	require.Equal(t, uint64(42), acc.GetAccountNumber(), "existing account must not be overwritten")
 }
 
+func TestFreeClaimDecorator_RejectsMultiMsgClaimTx(t *testing.T) {
+	claimerA := sdk.AccAddress([]byte("multi-claimer-addr-aaaaaaa"))
+	claimerB := sdk.AccAddress([]byte("multi-claimer-addr-bbbbbbb"))
+
+	ak := newFakeAccountKeeper()
+	decorator := ebifrost.NewFreeClaimDecorator(ak)
+
+	tx := fakeTx{
+		msgs: []sdk.Msg{
+			&types.MsgClaimWithProof{Claimer: claimerA.String()},
+			&types.MsgClaimWithProof{Claimer: claimerB.String()},
+		},
+		signers: [][]byte{claimerA, claimerB},
+		payer:   claimerA,
+	}
+
+	nextCalled := false
+	_, err := decorator.AnteHandle(sdk.Context{}, tx, false, func(ctx sdk.Context, _ sdk.Tx, _ bool) (sdk.Context, error) {
+		nextCalled = true
+		return ctx, nil
+	})
+
+	require.Error(t, err, "multi-msg claim tx must be rejected")
+	require.False(t, nextCalled, "next decorator must not run when ante rejects")
+	require.Nil(t, ak.GetAccount(context.Background(), claimerA),
+		"no accounts must be pre-created for a rejected multi-msg claim tx")
+	require.Nil(t, ak.GetAccount(context.Background(), claimerB),
+		"no accounts must be pre-created for a rejected multi-msg claim tx")
+}
+
 func TestFreeClaimDecorator_SkipsNonClaimTx(t *testing.T) {
 	sender := sdk.AccAddress([]byte("bank-sender-addr-1234567890"))
 

--- a/x/qbtc/ebifrost/free_claim_decorator_test.go
+++ b/x/qbtc/ebifrost/free_claim_decorator_test.go
@@ -1,0 +1,134 @@
+package ebifrost_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/btcq-org/qbtc/x/qbtc/ebifrost"
+	"github.com/btcq-org/qbtc/x/qbtc/types"
+	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	txsigning "github.com/cosmos/cosmos-sdk/types/tx/signing"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+)
+
+// fakeAccountKeeper is an in-memory AccountKeeper used to observe calls made by
+// FreeClaimDecorator without spinning up a real keeper.
+type fakeAccountKeeper struct {
+	accounts map[string]sdk.AccountI
+	nextNum  uint64
+}
+
+func newFakeAccountKeeper() *fakeAccountKeeper {
+	return &fakeAccountKeeper{accounts: map[string]sdk.AccountI{}}
+}
+
+func (f *fakeAccountKeeper) GetAccount(_ context.Context, addr sdk.AccAddress) sdk.AccountI {
+	return f.accounts[addr.String()]
+}
+
+func (f *fakeAccountKeeper) NewAccountWithAddress(_ context.Context, addr sdk.AccAddress) sdk.AccountI {
+	acc := authtypes.NewBaseAccountWithAddress(addr)
+	_ = acc.SetAccountNumber(f.nextNum)
+	f.nextNum++
+	return acc
+}
+
+func (f *fakeAccountKeeper) SetAccount(_ context.Context, acc sdk.AccountI) {
+	f.accounts[acc.GetAddress().String()] = acc
+}
+
+// fakeTx implements the minimum subset of sdk.Tx, authsigning.SigVerifiableTx
+// and sdk.FeeTx exercised by FreeClaimDecorator.
+type fakeTx struct {
+	msgs    []sdk.Msg
+	signers [][]byte
+	payer   []byte
+}
+
+func (t fakeTx) GetMsgs() []sdk.Msg                                { return t.msgs }
+func (t fakeTx) GetMsgsV2() ([]proto.Message, error)               { return nil, nil }
+func (t fakeTx) GetSigners() ([][]byte, error)                     { return t.signers, nil }
+func (t fakeTx) GetPubKeys() ([]cryptotypes.PubKey, error)         { return nil, nil }
+func (t fakeTx) GetSignaturesV2() ([]txsigning.SignatureV2, error) { return nil, nil }
+func (t fakeTx) GetGas() uint64                                    { return 0 }
+func (t fakeTx) GetFee() sdk.Coins                                 { return sdk.Coins{} }
+func (t fakeTx) FeePayer() []byte                                  { return t.payer }
+func (t fakeTx) FeeGranter() []byte                                { return nil }
+
+func TestFreeClaimDecorator_CreatesAccountForFirstTimeClaimer(t *testing.T) {
+	claimer := sdk.AccAddress([]byte("first-time-claimer-addr-01"))
+
+	ak := newFakeAccountKeeper()
+	decorator := ebifrost.NewFreeClaimDecorator(ak)
+
+	tx := fakeTx{
+		msgs:    []sdk.Msg{&types.MsgClaimWithProof{Claimer: claimer.String()}},
+		signers: [][]byte{claimer},
+		payer:   claimer,
+	}
+
+	nextCalled := false
+	_, err := decorator.AnteHandle(sdk.Context{}, tx, false, func(ctx sdk.Context, _ sdk.Tx, _ bool) (sdk.Context, error) {
+		nextCalled = true
+		return ctx, nil
+	})
+
+	require.NoError(t, err)
+	require.True(t, nextCalled, "next decorator should run")
+	require.NotNil(t, ak.GetAccount(context.Background(), claimer),
+		"claimer account must be pre-created so downstream decorators can look it up")
+}
+
+func TestFreeClaimDecorator_PreservesExistingAccount(t *testing.T) {
+	claimer := sdk.AccAddress([]byte("returning-claimer-addr-01"))
+
+	ak := newFakeAccountKeeper()
+	existing := authtypes.NewBaseAccountWithAddress(claimer)
+	_ = existing.SetAccountNumber(42)
+	ak.SetAccount(context.Background(), existing)
+
+	decorator := ebifrost.NewFreeClaimDecorator(ak)
+
+	tx := fakeTx{
+		msgs:    []sdk.Msg{&types.MsgClaimWithProof{Claimer: claimer.String()}},
+		signers: [][]byte{claimer},
+		payer:   claimer,
+	}
+
+	_, err := decorator.AnteHandle(sdk.Context{}, tx, false, func(ctx sdk.Context, _ sdk.Tx, _ bool) (sdk.Context, error) {
+		return ctx, nil
+	})
+	require.NoError(t, err)
+
+	acc := ak.GetAccount(context.Background(), claimer)
+	require.NotNil(t, acc)
+	require.Equal(t, uint64(42), acc.GetAccountNumber(), "existing account must not be overwritten")
+}
+
+func TestFreeClaimDecorator_SkipsNonClaimTx(t *testing.T) {
+	sender := sdk.AccAddress([]byte("bank-sender-addr-1234567890"))
+
+	ak := newFakeAccountKeeper()
+	decorator := ebifrost.NewFreeClaimDecorator(ak)
+
+	tx := fakeTx{
+		msgs: []sdk.Msg{&banktypes.MsgSend{
+			FromAddress: sender.String(),
+			ToAddress:   sender.String(),
+			Amount:      sdk.NewCoins(sdk.NewInt64Coin("uqbtc", 1)),
+		}},
+		signers: [][]byte{sender},
+		payer:   sender,
+	}
+
+	_, err := decorator.AnteHandle(sdk.Context{}, tx, false, func(ctx sdk.Context, _ sdk.Tx, _ bool) (sdk.Context, error) {
+		return ctx, nil
+	})
+	require.NoError(t, err)
+	require.Nil(t, ak.GetAccount(context.Background(), sender),
+		"non-claim txs must not trigger account pre-creation")
+}


### PR DESCRIPTION
## Summary

- Fixes #142 — `MsgClaimWithProof` was rejected for first-time claimers with `fee payer address: ... does not exist: unknown address`.
- `FreeClaimDecorator` already zeroed gas and min-gas-prices for claim-only txs, but `DeductFeeDecorator` (and later `SetPubKeyDecorator` / `SigVerificationDecorator`) still rejected the tx because the signer had no on-chain account yet. Every claim is by definition a fresh user's first interaction, so the gate made the feature unusable.
- Extend `FreeClaimDecorator` to pre-create signer and fee-payer accounts when absent. Downstream decorators now find the account, set the pubkey, and verify the signature normally.

## Why this is safe

- Only fires on claim-only txs (`isClaimOnlyTx`).
- No fee is charged (FreeClaimDecorator already enforces this).
- The claim is still gated by the ZK proof (bound to `(claimer, chain_id, version)`) and the MLDSA signature check downstream.
- `BankKeeper.SendCoinsFromModuleToAccount` would auto-create the account during mint anyway — we just move that creation earlier so the ante chain can proceed.

## Test plan

- [x] `go build ./...`
- [x] `make test-unit`
- [x] `make lint`
- [x] New unit tests in `x/qbtc/ebifrost/free_claim_decorator_test.go`:
  - Creates account when first-time claimer submits claim
  - Preserves existing account (doesn't overwrite account number)
  - Skips non-claim txs (doesn't touch account state)
- [ ] Manual repro from Vultisig `feat/qbtc-claim-ui` branch against a fresh vault

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Accounts are now automatically pre-created for users when processing claim transactions for a smoother claim flow.

* **Bug Fixes**
  * Claim-only transactions are validated to contain exactly one claim message; transactions with multiple claim messages are rejected. Non-claim transactions no longer trigger account pre-creation.

* **Tests**
  * Added tests covering claim handling, account pre-creation, and related success/error scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->