### PR TITLE
feat(proof-service): add optional on-chain broadcast

### DIFF
--- a/proof-service/broadcast.go
+++ b/proof-service/broadcast.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"sync/atomic"
 
+	"github.com/btcq-org/qbtc/common"
 	"github.com/btcq-org/qbtc/proof-service/config"
 	qbtctypes "github.com/btcq-org/qbtc/x/qbtc/types"
 	"github.com/cosmos/cosmos-sdk/client"
@@ -62,9 +63,13 @@ func NewBroadcaster(cfg config.Config) (*Broadcaster, error) {
 			return nil, fmt.Errorf("broadcast_priv_key_hex_list[%d]: expected 2560 bytes (5120 hex chars) for mldsa44, got %d bytes", i, len(privKeyBytes))
 		}
 		privKey := &mldsa.PrivKey{Key: privKeyBytes}
+		fromAddr, err := sdk.Bech32ifyAddressBytes(common.AccountAddressPrefix, privKey.PubKey().Address())
+		if err != nil {
+			return nil, fmt.Errorf("broadcast_priv_key_hex_list[%d]: failed to derive address: %w", i, err)
+		}
 		keys = append(keys, keyEntry{
 			privKey:  cryptotypes.PrivKey(privKey),
-			fromAddr: sdk.AccAddress(privKey.PubKey().Address()).String(),
+			fromAddr: fromAddr,
 		})
 	}
 

--- a/proof-service/broadcast.go
+++ b/proof-service/broadcast.go
@@ -1,0 +1,223 @@
+package proofservice
+
+import (
+	"context"
+	"encoding/hex"
+	"fmt"
+
+	"github.com/btcq-org/qbtc/proof-service/config"
+	qbtctypes "github.com/btcq-org/qbtc/x/qbtc/types"
+	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/codec"
+	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
+	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
+	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdktx "github.com/cosmos/cosmos-sdk/types/tx"
+	txsigning "github.com/cosmos/cosmos-sdk/types/tx/signing"
+	"github.com/cosmos/cosmos-sdk/std"
+	authsigning "github.com/cosmos/cosmos-sdk/x/auth/signing"
+	authtx "github.com/cosmos/cosmos-sdk/x/auth/tx"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+// Broadcaster signs and broadcasts MsgClaimWithProof transactions to the qbtc chain.
+type Broadcaster struct {
+	privKey   cryptotypes.PrivKey
+	fromAddr  string
+	chainID   string
+	fee       sdk.Coins
+	gasLimit  uint64
+	grpcConn *grpc.ClientConn
+	txConfig client.TxConfig
+	cdc      codec.Codec
+}
+
+// NewBroadcaster creates a Broadcaster from the service config.
+// Returns nil, nil when broadcasting is not configured (missing addr or key).
+func NewBroadcaster(cfg config.Config) (*Broadcaster, error) {
+	if cfg.BroadcastGRPCAddr == "" || cfg.BroadcastPrivKeyHex == "" {
+		return nil, nil
+	}
+
+	// Decode private key from hex
+	privKeyBytes, err := hex.DecodeString(cfg.BroadcastPrivKeyHex)
+	if err != nil {
+		return nil, fmt.Errorf("invalid broadcast_priv_key_hex: %w", err)
+	}
+	if len(privKeyBytes) != 32 {
+		return nil, fmt.Errorf("broadcast_priv_key_hex must be 64 hex characters (32 bytes), got %d bytes", len(privKeyBytes))
+	}
+	privKey := &secp256k1.PrivKey{Key: privKeyBytes}
+	fromAddr := sdk.AccAddress(privKey.PubKey().Address()).String()
+
+	// Parse fee
+	var fee sdk.Coins
+	if cfg.BroadcastFee != "" {
+		fee, err = sdk.ParseCoinsNormalized(cfg.BroadcastFee)
+		if err != nil {
+			return nil, fmt.Errorf("invalid broadcast_fee %q: %w", cfg.BroadcastFee, err)
+		}
+	}
+
+	// Set up codec and tx config
+	registry := codectypes.NewInterfaceRegistry()
+	std.RegisterInterfaces(registry)
+	qbtctypes.RegisterInterfaces(registry)
+	cdc := codec.NewProtoCodec(registry)
+	txConfig := authtx.NewTxConfig(cdc, authtx.DefaultSignModes)
+
+	// Connect to gRPC node
+	conn, err := grpc.NewClient(cfg.BroadcastGRPCAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		return nil, fmt.Errorf("failed to connect to gRPC node at %s: %w", cfg.BroadcastGRPCAddr, err)
+	}
+
+	gasLimit := cfg.BroadcastGasLimit
+	if gasLimit == 0 {
+		gasLimit = 200000
+	}
+
+	return &Broadcaster{
+		privKey:  privKey,
+		fromAddr: fromAddr,
+		chainID:  cfg.ChainID,
+		fee:      fee,
+		gasLimit: gasLimit,
+		grpcConn: conn,
+		txConfig: txConfig,
+		cdc:      cdc,
+	}, nil
+}
+
+// FromAddress returns the bech32 address that will sign and pay for transactions.
+func (b *Broadcaster) FromAddress() string {
+	return b.fromAddr
+}
+
+// Close releases the underlying gRPC connection.
+func (b *Broadcaster) Close() {
+	_ = b.grpcConn.Close()
+}
+
+// BroadcastClaim builds, signs, and broadcasts a MsgClaimWithProof derived from
+// the given ProveResponse. The claimer_address is used as the recipient.
+// Returns the transaction hash on success.
+func (b *Broadcaster) BroadcastClaim(ctx context.Context, resp *ProveResponse) (string, error) {
+	// Build the message
+	msg := &qbtctypes.MsgClaimWithProof{
+		Claimer:          resp.ClaimerAddress,
+		Utxos:            resp.UTXOs,
+		Proof:            resp.Proof,
+		MessageHash:      resp.MessageHash,
+		AddressHash:      resp.AddressHash,
+		QbtcAddressHash:  resp.QBTCAddressHash,
+		PubKeyHashSha256: resp.PubKeyHashSHA256,
+	}
+
+	// Fetch account number and sequence from chain
+	accountNum, seq, err := b.fetchAccountInfo(ctx)
+	if err != nil {
+		return "", fmt.Errorf("failed to fetch account info for %s: %w", b.fromAddr, err)
+	}
+
+	// Build tx
+	txBuilder := b.txConfig.NewTxBuilder()
+	if err := txBuilder.SetMsgs(msg); err != nil {
+		return "", fmt.Errorf("failed to set msgs: %w", err)
+	}
+	txBuilder.SetFeeAmount(b.fee)
+	txBuilder.SetGasLimit(b.gasLimit)
+
+	// Sign the tx
+	if err := b.signTx(ctx, txBuilder, accountNum, seq); err != nil {
+		return "", fmt.Errorf("failed to sign tx: %w", err)
+	}
+
+	// Encode and broadcast
+	txBytes, err := b.txConfig.TxEncoder()(txBuilder.GetTx())
+	if err != nil {
+		return "", fmt.Errorf("failed to encode tx: %w", err)
+	}
+
+	txClient := sdktx.NewServiceClient(b.grpcConn)
+	broadcastResp, err := txClient.BroadcastTx(ctx, &sdktx.BroadcastTxRequest{
+		TxBytes: txBytes,
+		Mode:    sdktx.BroadcastMode_BROADCAST_MODE_SYNC,
+	})
+	if err != nil {
+		return "", fmt.Errorf("broadcast rpc failed: %w", err)
+	}
+	if broadcastResp.TxResponse.Code != 0 {
+		return "", fmt.Errorf("tx rejected by chain (code %d): %s", broadcastResp.TxResponse.Code, broadcastResp.TxResponse.RawLog)
+	}
+
+	return broadcastResp.TxResponse.TxHash, nil
+}
+
+// fetchAccountInfo retrieves the account number and sequence for the broadcaster address.
+func (b *Broadcaster) fetchAccountInfo(ctx context.Context) (accountNum, seq uint64, err error) {
+	authClient := authtypes.NewQueryClient(b.grpcConn)
+	resp, err := authClient.Account(ctx, &authtypes.QueryAccountRequest{Address: b.fromAddr})
+	if err != nil {
+		return 0, 0, err
+	}
+
+	var account authtypes.BaseAccount
+	if err := b.cdc.Unmarshal(resp.Account.Value, &account); err != nil {
+		return 0, 0, fmt.Errorf("failed to unmarshal account: %w", err)
+	}
+	return account.AccountNumber, account.Sequence, nil
+}
+
+// signTx signs the tx builder in-place with the broadcaster's private key.
+func (b *Broadcaster) signTx(ctx context.Context, txBuilder client.TxBuilder, accountNum, seq uint64) error {
+	// Set empty signature first so the tx bytes are well-formed for sign-byte derivation.
+	emptySig := txsigning.SignatureV2{
+		PubKey: b.privKey.PubKey(),
+		Data: &txsigning.SingleSignatureData{
+			SignMode:  txsigning.SignMode_SIGN_MODE_DIRECT,
+			Signature: nil,
+		},
+		Sequence: seq,
+	}
+	if err := txBuilder.SetSignatures(emptySig); err != nil {
+		return err
+	}
+
+	signerData := authsigning.SignerData{
+		Address:       b.fromAddr,
+		ChainID:       b.chainID,
+		AccountNumber: accountNum,
+		Sequence:      seq,
+		PubKey:        b.privKey.PubKey(),
+	}
+
+	signBytes, err := authsigning.GetSignBytesAdapter(
+		ctx,
+		b.txConfig.SignModeHandler(),
+		txsigning.SignMode_SIGN_MODE_DIRECT,
+		signerData,
+		txBuilder.GetTx(),
+	)
+	if err != nil {
+		return fmt.Errorf("failed to get sign bytes: %w", err)
+	}
+
+	signature, err := b.privKey.Sign(signBytes)
+	if err != nil {
+		return fmt.Errorf("failed to sign: %w", err)
+	}
+
+	realSig := txsigning.SignatureV2{
+		PubKey: b.privKey.PubKey(),
+		Data: &txsigning.SingleSignatureData{
+			SignMode:  txsigning.SignMode_SIGN_MODE_DIRECT,
+			Signature: signature,
+		},
+		Sequence: seq,
+	}
+	return txBuilder.SetSignatures(realSig)
+}

--- a/proof-service/broadcast.go
+++ b/proof-service/broadcast.go
@@ -23,13 +23,14 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 )
 
+// gasAdjustment is the multiplier applied to the simulated gas usage.
+const gasAdjustment = 1.5
+
 // Broadcaster signs and broadcasts MsgClaimWithProof transactions to the qbtc chain.
 type Broadcaster struct {
-	privKey   cryptotypes.PrivKey
-	fromAddr  string
-	chainID   string
-	fee       sdk.Coins
-	gasLimit  uint64
+	privKey  cryptotypes.PrivKey
+	fromAddr string
+	chainID  string
 	grpcConn *grpc.ClientConn
 	txConfig client.TxConfig
 	cdc      codec.Codec
@@ -53,15 +54,6 @@ func NewBroadcaster(cfg config.Config) (*Broadcaster, error) {
 	privKey := &secp256k1.PrivKey{Key: privKeyBytes}
 	fromAddr := sdk.AccAddress(privKey.PubKey().Address()).String()
 
-	// Parse fee
-	var fee sdk.Coins
-	if cfg.BroadcastFee != "" {
-		fee, err = sdk.ParseCoinsNormalized(cfg.BroadcastFee)
-		if err != nil {
-			return nil, fmt.Errorf("invalid broadcast_fee %q: %w", cfg.BroadcastFee, err)
-		}
-	}
-
 	// Set up codec and tx config
 	registry := codectypes.NewInterfaceRegistry()
 	std.RegisterInterfaces(registry)
@@ -75,17 +67,10 @@ func NewBroadcaster(cfg config.Config) (*Broadcaster, error) {
 		return nil, fmt.Errorf("failed to connect to gRPC node at %s: %w", cfg.BroadcastGRPCAddr, err)
 	}
 
-	gasLimit := cfg.BroadcastGasLimit
-	if gasLimit == 0 {
-		gasLimit = 200000
-	}
-
 	return &Broadcaster{
 		privKey:  privKey,
 		fromAddr: fromAddr,
 		chainID:  cfg.ChainID,
-		fee:      fee,
-		gasLimit: gasLimit,
 		grpcConn: conn,
 		txConfig: txConfig,
 		cdc:      cdc,
@@ -103,7 +88,7 @@ func (b *Broadcaster) Close() {
 }
 
 // BroadcastClaim builds, signs, and broadcasts a MsgClaimWithProof derived from
-// the given ProveResponse. The claimer_address is used as the recipient.
+// the given ProveResponse. Gas is estimated via simulation. No fee is required.
 // Returns the transaction hash on success.
 func (b *Broadcaster) BroadcastClaim(ctx context.Context, resp *ProveResponse) (string, error) {
 	// Build the message
@@ -123,15 +108,31 @@ func (b *Broadcaster) BroadcastClaim(ctx context.Context, resp *ProveResponse) (
 		return "", fmt.Errorf("failed to fetch account info for %s: %w", b.fromAddr, err)
 	}
 
-	// Build tx
+	// Build tx with zero gas for simulation
 	txBuilder := b.txConfig.NewTxBuilder()
 	if err := txBuilder.SetMsgs(msg); err != nil {
 		return "", fmt.Errorf("failed to set msgs: %w", err)
 	}
-	txBuilder.SetFeeAmount(b.fee)
-	txBuilder.SetGasLimit(b.gasLimit)
+	txBuilder.SetGasLimit(0)
 
-	// Sign the tx
+	// Sign with zero gas to get valid tx bytes for simulation
+	if err := b.signTx(ctx, txBuilder, accountNum, seq); err != nil {
+		return "", fmt.Errorf("failed to sign tx for simulation: %w", err)
+	}
+
+	// Simulate to estimate gas
+	gasLimit, err := b.simulateGas(ctx, txBuilder)
+	if err != nil {
+		return "", fmt.Errorf("gas simulation failed: %w", err)
+	}
+
+	// Rebuild and re-sign with the estimated gas limit
+	txBuilder = b.txConfig.NewTxBuilder()
+	if err := txBuilder.SetMsgs(msg); err != nil {
+		return "", fmt.Errorf("failed to set msgs: %w", err)
+	}
+	txBuilder.SetGasLimit(gasLimit)
+
 	if err := b.signTx(ctx, txBuilder, accountNum, seq); err != nil {
 		return "", fmt.Errorf("failed to sign tx: %w", err)
 	}
@@ -155,6 +156,23 @@ func (b *Broadcaster) BroadcastClaim(ctx context.Context, resp *ProveResponse) (
 	}
 
 	return broadcastResp.TxResponse.TxHash, nil
+}
+
+// simulateGas encodes the current tx and calls the chain's Simulate RPC,
+// returning the adjusted gas limit (simulated * gasAdjustment).
+func (b *Broadcaster) simulateGas(ctx context.Context, txBuilder client.TxBuilder) (uint64, error) {
+	txBytes, err := b.txConfig.TxEncoder()(txBuilder.GetTx())
+	if err != nil {
+		return 0, fmt.Errorf("failed to encode tx for simulation: %w", err)
+	}
+
+	txClient := sdktx.NewServiceClient(b.grpcConn)
+	simResp, err := txClient.Simulate(ctx, &sdktx.SimulateRequest{TxBytes: txBytes})
+	if err != nil {
+		return 0, fmt.Errorf("simulate rpc failed: %w", err)
+	}
+
+	return uint64(float64(simResp.GasInfo.GasUsed) * gasAdjustment), nil
 }
 
 // fetchAccountInfo retrieves the account number and sequence for the broadcaster address.

--- a/proof-service/broadcast.go
+++ b/proof-service/broadcast.go
@@ -12,7 +12,6 @@ import (
 	"github.com/cosmos/cosmos-sdk/codec"
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	"github.com/cosmos/cosmos-sdk/crypto/keys/mldsa"
-	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
 	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdktx "github.com/cosmos/cosmos-sdk/types/tx"
@@ -52,24 +51,19 @@ func NewBroadcaster(cfg config.Config) (*Broadcaster, error) {
 		return nil, nil
 	}
 
-	// Decode all private keys. Supports secp256k1 (32 bytes) and ML-DSA-44 (2560 bytes).
+	// Decode all private keys (ML-DSA-44, 2560 bytes / 5120 hex chars).
 	keys := make([]keyEntry, 0, len(cfg.BroadcastPrivKeyHexList))
 	for i, hexKey := range cfg.BroadcastPrivKeyHexList {
 		privKeyBytes, err := hex.DecodeString(hexKey)
 		if err != nil {
 			return nil, fmt.Errorf("broadcast_priv_key_hex_list[%d]: invalid hex: %w", i, err)
 		}
-		var privKey cryptotypes.PrivKey
-		switch len(privKeyBytes) {
-		case 32:
-			privKey = &secp256k1.PrivKey{Key: privKeyBytes}
-		case 2560:
-			privKey = &mldsa.PrivKey{Key: privKeyBytes}
-		default:
-			return nil, fmt.Errorf("broadcast_priv_key_hex_list[%d]: unrecognised key length %d bytes (expected 32 for secp256k1 or 2560 for mldsa44)", i, len(privKeyBytes))
+		if len(privKeyBytes) != 2560 {
+			return nil, fmt.Errorf("broadcast_priv_key_hex_list[%d]: expected 2560 bytes (5120 hex chars) for mldsa44, got %d bytes", i, len(privKeyBytes))
 		}
+		privKey := &mldsa.PrivKey{Key: privKeyBytes}
 		keys = append(keys, keyEntry{
-			privKey:  privKey,
+			privKey:  cryptotypes.PrivKey(privKey),
 			fromAddr: sdk.AccAddress(privKey.PubKey().Address()).String(),
 		})
 	}

--- a/proof-service/broadcast.go
+++ b/proof-service/broadcast.go
@@ -11,6 +11,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/codec"
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
+	"github.com/cosmos/cosmos-sdk/crypto/keys/mldsa"
 	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
 	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -51,17 +52,22 @@ func NewBroadcaster(cfg config.Config) (*Broadcaster, error) {
 		return nil, nil
 	}
 
-	// Decode all private keys
+	// Decode all private keys. Supports secp256k1 (32 bytes) and ML-DSA-44 (2560 bytes).
 	keys := make([]keyEntry, 0, len(cfg.BroadcastPrivKeyHexList))
 	for i, hexKey := range cfg.BroadcastPrivKeyHexList {
 		privKeyBytes, err := hex.DecodeString(hexKey)
 		if err != nil {
 			return nil, fmt.Errorf("broadcast_priv_key_hex_list[%d]: invalid hex: %w", i, err)
 		}
-		if len(privKeyBytes) != 32 {
-			return nil, fmt.Errorf("broadcast_priv_key_hex_list[%d]: must be 64 hex characters (32 bytes), got %d bytes", i, len(privKeyBytes))
+		var privKey cryptotypes.PrivKey
+		switch len(privKeyBytes) {
+		case 32:
+			privKey = &secp256k1.PrivKey{Key: privKeyBytes}
+		case 2560:
+			privKey = &mldsa.PrivKey{Key: privKeyBytes}
+		default:
+			return nil, fmt.Errorf("broadcast_priv_key_hex_list[%d]: unrecognised key length %d bytes (expected 32 for secp256k1 or 2560 for mldsa44)", i, len(privKeyBytes))
 		}
-		privKey := &secp256k1.PrivKey{Key: privKeyBytes}
 		keys = append(keys, keyEntry{
 			privKey:  privKey,
 			fromAddr: sdk.AccAddress(privKey.PubKey().Address()).String(),

--- a/proof-service/broadcast.go
+++ b/proof-service/broadcast.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/hex"
 	"fmt"
+	"math"
+	"sync"
 	"sync/atomic"
 
 	"github.com/btcq-org/qbtc/common"
@@ -29,7 +31,10 @@ import (
 const gasAdjustment = 1.5
 
 // keyEntry holds a private key and its derived bech32 address.
+// mu serializes the fetch/sign/broadcast sequence so concurrent requests
+// using the same key cannot read the same account sequence.
 type keyEntry struct {
+	mu       sync.Mutex
 	privKey  cryptotypes.PrivKey
 	fromAddr string
 }
@@ -37,7 +42,7 @@ type keyEntry struct {
 // Broadcaster signs and broadcasts MsgClaimWithProof transactions to the qbtc chain.
 // Multiple signing keys are supported and selected in round-robin order.
 type Broadcaster struct {
-	keys     []keyEntry
+	keys     []*keyEntry
 	counter  atomic.Uint64
 	chainID  string
 	grpcConn *grpc.ClientConn
@@ -53,7 +58,7 @@ func NewBroadcaster(cfg config.Config) (*Broadcaster, error) {
 	}
 
 	// Decode all private keys (ML-DSA-44, 2560 bytes / 5120 hex chars).
-	keys := make([]keyEntry, 0, len(cfg.BroadcastPrivKeyHexList))
+	keys := make([]*keyEntry, 0, len(cfg.BroadcastPrivKeyHexList))
 	for i, hexKey := range cfg.BroadcastPrivKeyHexList {
 		privKeyBytes, err := hex.DecodeString(hexKey)
 		if err != nil {
@@ -67,7 +72,7 @@ func NewBroadcaster(cfg config.Config) (*Broadcaster, error) {
 		if err != nil {
 			return nil, fmt.Errorf("broadcast_priv_key_hex_list[%d]: failed to derive address: %w", i, err)
 		}
-		keys = append(keys, keyEntry{
+		keys = append(keys, &keyEntry{
 			privKey:  cryptotypes.PrivKey(privKey),
 			fromAddr: fromAddr,
 		})
@@ -105,7 +110,7 @@ func (b *Broadcaster) FromAddresses() []string {
 }
 
 // nextKey returns the next signing key in round-robin order.
-func (b *Broadcaster) nextKey() keyEntry {
+func (b *Broadcaster) nextKey() *keyEntry {
 	idx := b.counter.Add(1) - 1
 	return b.keys[idx%uint64(len(b.keys))]
 }
@@ -121,6 +126,8 @@ func (b *Broadcaster) Close() {
 // Returns the transaction hash on success.
 func (b *Broadcaster) BroadcastClaim(ctx context.Context, resp *ProveResponse) (string, error) {
 	key := b.nextKey()
+	key.mu.Lock()
+	defer key.mu.Unlock()
 
 	// Build the message
 	msg := &qbtctypes.MsgClaimWithProof{
@@ -203,7 +210,7 @@ func (b *Broadcaster) simulateGas(ctx context.Context, txBuilder client.TxBuilde
 		return 0, fmt.Errorf("simulate rpc failed: %w", err)
 	}
 
-	return uint64(float64(simResp.GasInfo.GasUsed) * gasAdjustment), nil
+	return uint64(math.Ceil(float64(simResp.GasInfo.GasUsed) * gasAdjustment)), nil
 }
 
 // fetchAccountInfo retrieves the account number and sequence for the given address.
@@ -222,7 +229,7 @@ func (b *Broadcaster) fetchAccountInfo(ctx context.Context, addr string) (accoun
 }
 
 // signTx signs the tx builder in-place with the given key.
-func (b *Broadcaster) signTx(ctx context.Context, key keyEntry, txBuilder client.TxBuilder, accountNum, seq uint64) error {
+func (b *Broadcaster) signTx(ctx context.Context, key *keyEntry, txBuilder client.TxBuilder, accountNum, seq uint64) error {
 	// Set empty signature first so the tx bytes are well-formed for sign-byte derivation.
 	emptySig := txsigning.SignatureV2{
 		PubKey: key.privKey.PubKey(),

--- a/proof-service/broadcast.go
+++ b/proof-service/broadcast.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/hex"
 	"fmt"
+	"sync/atomic"
 
 	"github.com/btcq-org/qbtc/proof-service/config"
 	qbtctypes "github.com/btcq-org/qbtc/x/qbtc/types"
@@ -26,10 +27,17 @@ import (
 // gasAdjustment is the multiplier applied to the simulated gas usage.
 const gasAdjustment = 1.5
 
-// Broadcaster signs and broadcasts MsgClaimWithProof transactions to the qbtc chain.
-type Broadcaster struct {
+// keyEntry holds a private key and its derived bech32 address.
+type keyEntry struct {
 	privKey  cryptotypes.PrivKey
 	fromAddr string
+}
+
+// Broadcaster signs and broadcasts MsgClaimWithProof transactions to the qbtc chain.
+// Multiple signing keys are supported and selected in round-robin order.
+type Broadcaster struct {
+	keys     []keyEntry
+	counter  atomic.Uint64
 	chainID  string
 	grpcConn *grpc.ClientConn
 	txConfig client.TxConfig
@@ -37,22 +45,28 @@ type Broadcaster struct {
 }
 
 // NewBroadcaster creates a Broadcaster from the service config.
-// Returns nil, nil when broadcasting is not configured (missing addr or key).
+// Returns nil, nil when broadcasting is not configured (missing addr or keys).
 func NewBroadcaster(cfg config.Config) (*Broadcaster, error) {
-	if cfg.BroadcastGRPCAddr == "" || cfg.BroadcastPrivKeyHex == "" {
+	if cfg.BroadcastGRPCAddr == "" || len(cfg.BroadcastPrivKeyHexList) == 0 {
 		return nil, nil
 	}
 
-	// Decode private key from hex
-	privKeyBytes, err := hex.DecodeString(cfg.BroadcastPrivKeyHex)
-	if err != nil {
-		return nil, fmt.Errorf("invalid broadcast_priv_key_hex: %w", err)
+	// Decode all private keys
+	keys := make([]keyEntry, 0, len(cfg.BroadcastPrivKeyHexList))
+	for i, hexKey := range cfg.BroadcastPrivKeyHexList {
+		privKeyBytes, err := hex.DecodeString(hexKey)
+		if err != nil {
+			return nil, fmt.Errorf("broadcast_priv_key_hex_list[%d]: invalid hex: %w", i, err)
+		}
+		if len(privKeyBytes) != 32 {
+			return nil, fmt.Errorf("broadcast_priv_key_hex_list[%d]: must be 64 hex characters (32 bytes), got %d bytes", i, len(privKeyBytes))
+		}
+		privKey := &secp256k1.PrivKey{Key: privKeyBytes}
+		keys = append(keys, keyEntry{
+			privKey:  privKey,
+			fromAddr: sdk.AccAddress(privKey.PubKey().Address()).String(),
+		})
 	}
-	if len(privKeyBytes) != 32 {
-		return nil, fmt.Errorf("broadcast_priv_key_hex must be 64 hex characters (32 bytes), got %d bytes", len(privKeyBytes))
-	}
-	privKey := &secp256k1.PrivKey{Key: privKeyBytes}
-	fromAddr := sdk.AccAddress(privKey.PubKey().Address()).String()
 
 	// Set up codec and tx config
 	registry := codectypes.NewInterfaceRegistry()
@@ -68,8 +82,7 @@ func NewBroadcaster(cfg config.Config) (*Broadcaster, error) {
 	}
 
 	return &Broadcaster{
-		privKey:  privKey,
-		fromAddr: fromAddr,
+		keys:     keys,
 		chainID:  cfg.ChainID,
 		grpcConn: conn,
 		txConfig: txConfig,
@@ -77,9 +90,19 @@ func NewBroadcaster(cfg config.Config) (*Broadcaster, error) {
 	}, nil
 }
 
-// FromAddress returns the bech32 address that will sign and pay for transactions.
-func (b *Broadcaster) FromAddress() string {
-	return b.fromAddr
+// FromAddresses returns the bech32 addresses of all configured signing keys.
+func (b *Broadcaster) FromAddresses() []string {
+	addrs := make([]string, len(b.keys))
+	for i, k := range b.keys {
+		addrs[i] = k.fromAddr
+	}
+	return addrs
+}
+
+// nextKey returns the next signing key in round-robin order.
+func (b *Broadcaster) nextKey() keyEntry {
+	idx := b.counter.Add(1) - 1
+	return b.keys[idx%uint64(len(b.keys))]
 }
 
 // Close releases the underlying gRPC connection.
@@ -88,9 +111,12 @@ func (b *Broadcaster) Close() {
 }
 
 // BroadcastClaim builds, signs, and broadcasts a MsgClaimWithProof derived from
-// the given ProveResponse. Gas is estimated via simulation. No fee is required.
+// the given ProveResponse. A signing key is chosen in round-robin order.
+// Gas is estimated via simulation. No fee is required.
 // Returns the transaction hash on success.
 func (b *Broadcaster) BroadcastClaim(ctx context.Context, resp *ProveResponse) (string, error) {
+	key := b.nextKey()
+
 	// Build the message
 	msg := &qbtctypes.MsgClaimWithProof{
 		Claimer:          resp.ClaimerAddress,
@@ -103,9 +129,9 @@ func (b *Broadcaster) BroadcastClaim(ctx context.Context, resp *ProveResponse) (
 	}
 
 	// Fetch account number and sequence from chain
-	accountNum, seq, err := b.fetchAccountInfo(ctx)
+	accountNum, seq, err := b.fetchAccountInfo(ctx, key.fromAddr)
 	if err != nil {
-		return "", fmt.Errorf("failed to fetch account info for %s: %w", b.fromAddr, err)
+		return "", fmt.Errorf("failed to fetch account info for %s: %w", key.fromAddr, err)
 	}
 
 	// Build tx with zero gas for simulation
@@ -116,7 +142,7 @@ func (b *Broadcaster) BroadcastClaim(ctx context.Context, resp *ProveResponse) (
 	txBuilder.SetGasLimit(0)
 
 	// Sign with zero gas to get valid tx bytes for simulation
-	if err := b.signTx(ctx, txBuilder, accountNum, seq); err != nil {
+	if err := b.signTx(ctx, key, txBuilder, accountNum, seq); err != nil {
 		return "", fmt.Errorf("failed to sign tx for simulation: %w", err)
 	}
 
@@ -133,7 +159,7 @@ func (b *Broadcaster) BroadcastClaim(ctx context.Context, resp *ProveResponse) (
 	}
 	txBuilder.SetGasLimit(gasLimit)
 
-	if err := b.signTx(ctx, txBuilder, accountNum, seq); err != nil {
+	if err := b.signTx(ctx, key, txBuilder, accountNum, seq); err != nil {
 		return "", fmt.Errorf("failed to sign tx: %w", err)
 	}
 
@@ -175,10 +201,10 @@ func (b *Broadcaster) simulateGas(ctx context.Context, txBuilder client.TxBuilde
 	return uint64(float64(simResp.GasInfo.GasUsed) * gasAdjustment), nil
 }
 
-// fetchAccountInfo retrieves the account number and sequence for the broadcaster address.
-func (b *Broadcaster) fetchAccountInfo(ctx context.Context) (accountNum, seq uint64, err error) {
+// fetchAccountInfo retrieves the account number and sequence for the given address.
+func (b *Broadcaster) fetchAccountInfo(ctx context.Context, addr string) (accountNum, seq uint64, err error) {
 	authClient := authtypes.NewQueryClient(b.grpcConn)
-	resp, err := authClient.Account(ctx, &authtypes.QueryAccountRequest{Address: b.fromAddr})
+	resp, err := authClient.Account(ctx, &authtypes.QueryAccountRequest{Address: addr})
 	if err != nil {
 		return 0, 0, err
 	}
@@ -190,11 +216,11 @@ func (b *Broadcaster) fetchAccountInfo(ctx context.Context) (accountNum, seq uin
 	return account.AccountNumber, account.Sequence, nil
 }
 
-// signTx signs the tx builder in-place with the broadcaster's private key.
-func (b *Broadcaster) signTx(ctx context.Context, txBuilder client.TxBuilder, accountNum, seq uint64) error {
+// signTx signs the tx builder in-place with the given key.
+func (b *Broadcaster) signTx(ctx context.Context, key keyEntry, txBuilder client.TxBuilder, accountNum, seq uint64) error {
 	// Set empty signature first so the tx bytes are well-formed for sign-byte derivation.
 	emptySig := txsigning.SignatureV2{
-		PubKey: b.privKey.PubKey(),
+		PubKey: key.privKey.PubKey(),
 		Data: &txsigning.SingleSignatureData{
 			SignMode:  txsigning.SignMode_SIGN_MODE_DIRECT,
 			Signature: nil,
@@ -206,11 +232,11 @@ func (b *Broadcaster) signTx(ctx context.Context, txBuilder client.TxBuilder, ac
 	}
 
 	signerData := authsigning.SignerData{
-		Address:       b.fromAddr,
+		Address:       key.fromAddr,
 		ChainID:       b.chainID,
 		AccountNumber: accountNum,
 		Sequence:      seq,
-		PubKey:        b.privKey.PubKey(),
+		PubKey:        key.privKey.PubKey(),
 	}
 
 	signBytes, err := authsigning.GetSignBytesAdapter(
@@ -224,13 +250,13 @@ func (b *Broadcaster) signTx(ctx context.Context, txBuilder client.TxBuilder, ac
 		return fmt.Errorf("failed to get sign bytes: %w", err)
 	}
 
-	signature, err := b.privKey.Sign(signBytes)
+	signature, err := key.privKey.Sign(signBytes)
 	if err != nil {
 		return fmt.Errorf("failed to sign: %w", err)
 	}
 
 	realSig := txsigning.SignatureV2{
-		PubKey: b.privKey.PubKey(),
+		PubKey: key.privKey.PubKey(),
 		Data: &txsigning.SingleSignatureData{
 			SignMode:  txsigning.SignMode_SIGN_MODE_DIRECT,
 			Signature: signature,

--- a/proof-service/config/config.go
+++ b/proof-service/config/config.go
@@ -25,10 +25,9 @@ type Config struct {
 	// Leave empty to disable on-chain broadcasting.
 	BroadcastGRPCAddr string `mapstructure:"broadcast_grpc_addr" json:"broadcast_grpc_addr,omitempty"`
 
-	// BroadcastPrivKeyHex is the hex-encoded secp256k1 private key used to sign and broadcast claim txs.
-	// Leave empty to disable on-chain broadcasting.
-	BroadcastPrivKeyHex string `mapstructure:"broadcast_priv_key_hex" json:"broadcast_priv_key_hex,omitempty"`
-
+	// BroadcastPrivKeyHexList is a list of hex-encoded secp256k1 private keys used to sign and
+	// broadcast claim txs. Keys are selected in round-robin order. Leave empty to disable broadcasting.
+	BroadcastPrivKeyHexList []string `mapstructure:"broadcast_priv_key_hex_list" json:"broadcast_priv_key_hex_list,omitempty"`
 }
 
 // DefaultConfig returns a Config with sensible defaults.

--- a/proof-service/config/config.go
+++ b/proof-service/config/config.go
@@ -29,11 +29,6 @@ type Config struct {
 	// Leave empty to disable on-chain broadcasting.
 	BroadcastPrivKeyHex string `mapstructure:"broadcast_priv_key_hex" json:"broadcast_priv_key_hex,omitempty"`
 
-	// BroadcastFee is the tx fee paid when broadcasting (e.g. "1000uqbtc").
-	BroadcastFee string `mapstructure:"broadcast_fee" json:"broadcast_fee,omitempty"`
-
-	// BroadcastGasLimit is the gas limit for broadcast txs (e.g. 200000).
-	BroadcastGasLimit uint64 `mapstructure:"broadcast_gas_limit" json:"broadcast_gas_limit,omitempty"`
 }
 
 // DefaultConfig returns a Config with sensible defaults.

--- a/proof-service/config/config.go
+++ b/proof-service/config/config.go
@@ -25,8 +25,11 @@ type Config struct {
 	// Leave empty to disable on-chain broadcasting.
 	BroadcastGRPCAddr string `mapstructure:"broadcast_grpc_addr" json:"broadcast_grpc_addr,omitempty"`
 
-	// BroadcastPrivKeyHexList is a list of hex-encoded secp256k1 private keys used to sign and
-	// broadcast claim txs. Keys are selected in round-robin order. Leave empty to disable broadcasting.
+	// BroadcastPrivKeyHexList is a list of hex-encoded private keys used to sign and broadcast claim
+	// txs. Keys are selected in round-robin order. Leave empty to disable broadcasting.
+	// Supported key types (detected by byte length):
+	//   - secp256k1:  32 bytes  (64  hex chars)
+	//   - mldsa44:   2560 bytes (5120 hex chars)
 	BroadcastPrivKeyHexList []string `mapstructure:"broadcast_priv_key_hex_list" json:"broadcast_priv_key_hex_list,omitempty"`
 }
 

--- a/proof-service/config/config.go
+++ b/proof-service/config/config.go
@@ -25,11 +25,9 @@ type Config struct {
 	// Leave empty to disable on-chain broadcasting.
 	BroadcastGRPCAddr string `mapstructure:"broadcast_grpc_addr" json:"broadcast_grpc_addr,omitempty"`
 
-	// BroadcastPrivKeyHexList is a list of hex-encoded private keys used to sign and broadcast claim
-	// txs. Keys are selected in round-robin order. Leave empty to disable broadcasting.
-	// Supported key types (detected by byte length):
-	//   - secp256k1:  32 bytes  (64  hex chars)
-	//   - mldsa44:   2560 bytes (5120 hex chars)
+	// BroadcastPrivKeyHexList is a list of hex-encoded ML-DSA-44 private keys (2560 bytes / 5120 hex
+	// chars each) used to sign and broadcast claim txs. Keys are selected in round-robin order.
+	// Leave empty to disable broadcasting.
 	BroadcastPrivKeyHexList []string `mapstructure:"broadcast_priv_key_hex_list" json:"broadcast_priv_key_hex_list,omitempty"`
 }
 

--- a/proof-service/config/config.go
+++ b/proof-service/config/config.go
@@ -20,6 +20,20 @@ type Config struct {
 
 	// RequestTimeoutSec is the maximum time allowed for proof generation.
 	RequestTimeoutSec int `mapstructure:"request_timeout_sec" json:"request_timeout_sec"`
+
+	// BroadcastGRPCAddr is the gRPC endpoint of the qbtc node to broadcast to (e.g. "localhost:9090").
+	// Leave empty to disable on-chain broadcasting.
+	BroadcastGRPCAddr string `mapstructure:"broadcast_grpc_addr" json:"broadcast_grpc_addr,omitempty"`
+
+	// BroadcastPrivKeyHex is the hex-encoded secp256k1 private key used to sign and broadcast claim txs.
+	// Leave empty to disable on-chain broadcasting.
+	BroadcastPrivKeyHex string `mapstructure:"broadcast_priv_key_hex" json:"broadcast_priv_key_hex,omitempty"`
+
+	// BroadcastFee is the tx fee paid when broadcasting (e.g. "1000uqbtc").
+	BroadcastFee string `mapstructure:"broadcast_fee" json:"broadcast_fee,omitempty"`
+
+	// BroadcastGasLimit is the gas limit for broadcast txs (e.g. 200000).
+	BroadcastGasLimit uint64 `mapstructure:"broadcast_gas_limit" json:"broadcast_gas_limit,omitempty"`
 }
 
 // DefaultConfig returns a Config with sensible defaults.

--- a/proof-service/config/config.go
+++ b/proof-service/config/config.go
@@ -28,7 +28,7 @@ type Config struct {
 	// BroadcastPrivKeyHexList is a list of hex-encoded ML-DSA-44 private keys (2560 bytes / 5120 hex
 	// chars each) used to sign and broadcast claim txs. Keys are selected in round-robin order.
 	// Leave empty to disable broadcasting.
-	BroadcastPrivKeyHexList []string `mapstructure:"broadcast_priv_key_hex_list" json:"broadcast_priv_key_hex_list,omitempty"`
+	BroadcastPrivKeyHexList []string `mapstructure:"broadcast_priv_key_hex_list" json:"-"`
 }
 
 // DefaultConfig returns a Config with sensible defaults.

--- a/proof-service/http.go
+++ b/proof-service/http.go
@@ -29,6 +29,11 @@ type ProveRequest struct {
 	// ChainID for message binding (e.g., "qbtc-1").
 	// If empty, uses the configured default.
 	ChainID string `json:"chain_id,omitempty"`
+
+	// Broadcast, if true, submits the resulting MsgClaimWithProof to the chain
+	// after proof generation. Requires broadcast_grpc_addr and broadcast_priv_key_hex
+	// to be configured in the service config.
+	Broadcast bool `json:"broadcast,omitempty"`
 }
 
 // ProveResponse is the JSON response for POST /prove.
@@ -56,6 +61,9 @@ type ProveResponse struct {
 
 	// ClaimerAddress is the claimer address (echoed back).
 	ClaimerAddress string `json:"claimer_address"`
+
+	// TxHash is the on-chain transaction hash, populated only when broadcast=true.
+	TxHash string `json:"tx_hash,omitempty"`
 }
 
 // ErrorResponse is returned for error cases.
@@ -109,7 +117,7 @@ func (s *Service) handleProve(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Validate and generate proof
-	resp, httpCode, errResp := s.generateProof(req)
+	resp, httpCode, errResp := s.generateProof(r.Context(), req)
 	if errResp != nil {
 		s.metrics.IncrCounter(metrics.MetricProofsFailed)
 		s.writeErrorStruct(w, httpCode, errResp)

--- a/proof-service/prove.go
+++ b/proof-service/prove.go
@@ -14,7 +14,24 @@ func (s *Service) generateProof(ctx context.Context, req ProveRequest) (*ProveRe
 	s.logger.Info().Str("claimer_address", req.ClaimerAddress).
 		Int("num_utxos", len(req.UTXOs)).
 		Msg("received proof generation request")
-	// 1. Validate required fields
+
+	// 1. Fail-fast broadcast pre-checks before doing any ZK work.
+	if req.Broadcast {
+		if s.broadcaster == nil {
+			return nil, http.StatusBadRequest, &ErrorResponse{
+				Error: "broadcasting is not configured on this service",
+				Code:  "BROADCAST_NOT_CONFIGURED",
+			}
+		}
+		if req.ChainID != "" && req.ChainID != s.cfg.ChainID {
+			return nil, http.StatusBadRequest, &ErrorResponse{
+				Error: "chain_id must match the service chain when broadcast=true",
+				Code:  "CHAIN_ID_MISMATCH",
+			}
+		}
+	}
+
+	// 2. Validate required fields
 	if req.SignatureR == "" || req.SignatureS == "" {
 		return nil, http.StatusBadRequest, &ErrorResponse{
 			Error: "signature_r and signature_s are required",
@@ -144,12 +161,6 @@ func (s *Service) generateProof(ctx context.Context, req ProveRequest) (*ProveRe
 
 	// 11. Optionally broadcast the claim to the chain
 	if req.Broadcast {
-		if s.broadcaster == nil {
-			return nil, http.StatusBadRequest, &ErrorResponse{
-				Error: "broadcasting is not configured on this service",
-				Code:  "BROADCAST_NOT_CONFIGURED",
-			}
-		}
 		txHash, err := s.broadcaster.BroadcastClaim(ctx, resp)
 		if err != nil {
 			s.logger.Error().Err(err).Msg("broadcast failed")

--- a/proof-service/prove.go
+++ b/proof-service/prove.go
@@ -1,6 +1,7 @@
 package proofservice
 
 import (
+	"context"
 	"encoding/hex"
 	"math/big"
 	"net/http"
@@ -9,7 +10,7 @@ import (
 	"github.com/btcsuite/btcd/btcec/v2"
 )
 
-func (s *Service) generateProof(req ProveRequest) (*ProveResponse, int, *ErrorResponse) {
+func (s *Service) generateProof(ctx context.Context, req ProveRequest) (*ProveResponse, int, *ErrorResponse) {
 	s.logger.Info().Str("claimer_address", req.ClaimerAddress).
 		Int("num_utxos", len(req.UTXOs)).
 		Msg("received proof generation request")
@@ -131,7 +132,7 @@ func (s *Service) generateProof(req ProveRequest) (*ProveResponse, int, *ErrorRe
 	}
 
 	// 10. Build response
-	return &ProveResponse{
+	resp := &ProveResponse{
 		Proof:            hex.EncodeToString(proofBytes),
 		MessageHash:      hex.EncodeToString(messageHash[:]),
 		AddressHash:      hex.EncodeToString(addressHash[:]),
@@ -139,5 +140,28 @@ func (s *Service) generateProof(req ProveRequest) (*ProveResponse, int, *ErrorRe
 		QBTCAddressHash:  hex.EncodeToString(qbtcAddressHash[:]),
 		UTXOs:            req.UTXOs,
 		ClaimerAddress:   req.ClaimerAddress,
-	}, http.StatusOK, nil
+	}
+
+	// 11. Optionally broadcast the claim to the chain
+	if req.Broadcast {
+		if s.broadcaster == nil {
+			return nil, http.StatusBadRequest, &ErrorResponse{
+				Error: "broadcasting is not configured on this service",
+				Code:  "BROADCAST_NOT_CONFIGURED",
+			}
+		}
+		txHash, err := s.broadcaster.BroadcastClaim(ctx, resp)
+		if err != nil {
+			s.logger.Error().Err(err).Msg("broadcast failed")
+			return nil, http.StatusInternalServerError, &ErrorResponse{
+				Error:   "broadcast failed",
+				Code:    "BROADCAST_FAILED",
+				Details: err.Error(),
+			}
+		}
+		resp.TxHash = txHash
+		s.logger.Info().Str("tx_hash", txHash).Msg("broadcast claim tx")
+	}
+
+	return resp, http.StatusOK, nil
 }

--- a/proof-service/service.go
+++ b/proof-service/service.go
@@ -30,6 +30,9 @@ type Service struct {
 	// Chain ID hash (precomputed at startup)
 	chainIDHash [8]byte
 
+	// Optional on-chain broadcaster (nil when not configured)
+	broadcaster *Broadcaster
+
 	// HTTP server
 	hs *http.Server
 
@@ -73,6 +76,15 @@ func NewService(cfg config.Config) (*Service, error) {
 	chainIDHash := zk.ComputeChainIDHash(cfg.ChainID)
 	logger.Info().Str("chain_id", cfg.ChainID).Msg("computed chain ID hash")
 
+	// Optionally create broadcaster
+	broadcaster, err := NewBroadcaster(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize broadcaster: %w", err)
+	}
+	if broadcaster != nil {
+		logger.Info().Str("from_addr", broadcaster.FromAddress()).Str("grpc_addr", cfg.BroadcastGRPCAddr).Msg("broadcaster enabled")
+	}
+
 	// Create metrics
 	m := metrics.NewMetrics()
 
@@ -90,6 +102,7 @@ func NewService(cfg config.Config) (*Service, error) {
 		cs:          cs,
 		pk:          pk,
 		chainIDHash: chainIDHash,
+		broadcaster: broadcaster,
 		hs:          hs,
 		metrics:     m,
 		stopChan:    make(chan struct{}),
@@ -138,5 +151,10 @@ func (s *Service) Stop() {
 	}
 
 	s.wg.Wait()
+
+	if s.broadcaster != nil {
+		s.broadcaster.Close()
+	}
+
 	s.logger.Info().Msg("proof-service stopped")
 }

--- a/proof-service/service.go
+++ b/proof-service/service.go
@@ -82,7 +82,7 @@ func NewService(cfg config.Config) (*Service, error) {
 		return nil, fmt.Errorf("failed to initialize broadcaster: %w", err)
 	}
 	if broadcaster != nil {
-		logger.Info().Str("from_addr", broadcaster.FromAddress()).Str("grpc_addr", cfg.BroadcastGRPCAddr).Msg("broadcaster enabled")
+		logger.Info().Strs("from_addrs", broadcaster.FromAddresses()).Str("grpc_addr", cfg.BroadcastGRPCAddr).Msg("broadcaster enabled")
 	}
 
 	// Create metrics


### PR DESCRIPTION
## Summary

- Adds `broadcast: true` option to `ProveRequest` — when set, the service submits a `MsgClaimWithProof` to the qbtc chain immediately after generating the proof and returns the `tx_hash` in the response
- Signing key (`broadcast_priv_key_hex`) and node endpoint (`broadcast_grpc_addr`) are configured once in `config.json`; the feature is disabled when either field is empty
- New `Broadcaster` in `proof-service/broadcast.go` handles key loading, codec setup, account info fetch, SIGN_MODE_DIRECT signing, and gRPC broadcast

## Config

```json
{
  "broadcast_grpc_addr": "localhost:9090",
  "broadcast_priv_key_hex": "<64-char hex secp256k1 key>",
  "broadcast_fee": "1000uqbtc",
  "broadcast_gas_limit": 200000
}
```

## Request / Response

```json
// request
{ "broadcast": true, "claimer_address": "qbtc1...", ... }

// response (broadcast=true)
{ "proof": "...", "tx_hash": "ABC123...", ... }
```

## Test plan

- [ ] Build passes: `make build`
- [ ] `broadcast: false` (or omitted) — response unchanged, no `tx_hash`
- [ ] `broadcast: true` with no broadcast config — returns `BROADCAST_NOT_CONFIGURED` error
- [ ] `broadcast: true` with config pointing at a running local node — response includes `tx_hash`, verifiable with `qbtcd q tx <hash>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * API accepts a broadcast flag to submit generated proofs on-chain and returns a transaction hash on success.
  * New config options to enable broadcasting and provide broadcast node address and private keys.
  * Service initializes broadcasting on startup (when configured) and shuts it down cleanly.

* **Behavior / Errors**
  * Requests that ask to broadcast but lack configuration return a clear client error.
  * Chain ID mismatches and broadcast failures return appropriate error responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->