### PR TITLE
fix(e2e): plug temp-dir leak and add GetTxCmd interface assertion

### DIFF
--- a/x/qbtc/client/testutil/cli_helpers.go
+++ b/x/qbtc/client/testutil/cli_helpers.go
@@ -33,6 +33,7 @@ func MsgClaimWithProofExec(
 	if err != nil {
 		return nil, err
 	}
+	defer os.RemoveAll(tmpDir)
 	path := filepath.Join(tmpDir, "msg.json")
 	if err := os.WriteFile(path, bz, 0o600); err != nil {
 		return nil, err

--- a/x/qbtc/module/module.go
+++ b/x/qbtc/module/module.go
@@ -28,6 +28,8 @@ var (
 	_ appmodule.AppModule       = (*AppModule)(nil)
 	_ appmodule.HasBeginBlocker = (*AppModule)(nil)
 	_ appmodule.HasEndBlocker   = (*AppModule)(nil)
+
+	_ interface{ GetTxCmd() *cobra.Command } = (*AppModule)(nil)
 )
 
 // AppModule implements the AppModule interface that defines the inter-dependent methods that modules need to implement


### PR DESCRIPTION
Defer os.RemoveAll in MsgClaimWithProofExec so the temp dir created for the JSON file is always cleaned up after ExecTestCLICmd returns.

Add a compile-time interface assertion for GetTxCmd() on AppModule so any future removal of the method is caught at build time.