### PR TITLE
Revert "refactor(types): remove GetSigners and sdk.LegacyMsg from message types"

### DIFF
--- a/x/qbtc/types/msg_report_block.go
+++ b/x/qbtc/types/msg_report_block.go
@@ -32,6 +32,13 @@ func (m *MsgBtcBlock) ValidateBasic() error {
 	}
 	return nil
 }
+func (m *MsgBtcBlock) GetSigners() []sdk.AccAddress {
+	creator, err := sdk.AccAddressFromBech32(m.Signer)
+	if err != nil {
+		panic(err)
+	}
+	return []sdk.AccAddress{creator}
+}
 
 func (m *MsgBtcBlock) GetAttestations() []*Attestation {
 	return m.Attestations

--- a/x/qbtc/types/msg_set_node_peer_address.go
+++ b/x/qbtc/types/msg_set_node_peer_address.go
@@ -11,6 +11,7 @@ import (
 var (
 	_ sdk.Msg              = &MsgSetNodePeerAddress{}
 	_ sdk.HasValidateBasic = &MsgSetNodePeerAddress{}
+	_ sdk.LegacyMsg        = &MsgSetNodePeerAddress{}
 )
 
 // ValidatePeerAddress validates the format of a peer address: <peerID>@<host>:<port>
@@ -68,4 +69,10 @@ func (m *MsgSetNodePeerAddress) ValidateBasic() error {
 
 	// Use shared validation function
 	return ValidatePeerAddress(m.PeerAddress)
+}
+
+// GetSigners defines whose signature is required
+func (m *MsgSetNodePeerAddress) GetSigners() []sdk.AccAddress {
+	acct, _ := sdk.AccAddressFromBech32(m.Signer)
+	return []sdk.AccAddress{acct}
 }


### PR DESCRIPTION
Reverts btcq-org/qbtc#149

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced internal message signing infrastructure to improve protocol compliance and signature routing capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->