### PR TITLE
fix(app): move test helpers to app/testutil to fix tx config DI override

### DIFF
--- a/app/testutil/helpers.go
+++ b/app/testutil/helpers.go
@@ -1,4 +1,4 @@
-package app
+package apptestutil
 
 import (
 	"fmt"
@@ -15,6 +15,8 @@ import (
 	"github.com/cosmos/cosmos-sdk/testutil/network"
 	simtestutil "github.com/cosmos/cosmos-sdk/testutil/sims"
 	moduletestutil "github.com/cosmos/cosmos-sdk/types/module/testutil"
+
+	"github.com/btcq-org/qbtc/app"
 )
 
 // NewTestNetworkFixture returns a TestFixture for cosmos-sdk's testutil/network
@@ -32,7 +34,7 @@ func NewTestNetworkFixture() network.TestFixture {
 	}
 	defer os.RemoveAll(dir)
 
-	tmpApp := New(
+	tmpApp := app.New(
 		log.NewNopLogger(),
 		dbm.NewMemDB(),
 		nil,
@@ -42,7 +44,7 @@ func NewTestNetworkFixture() network.TestFixture {
 
 	return network.TestFixture{
 		AppConstructor: func(val network.ValidatorI) servertypes.Application {
-			return New(
+			return app.New(
 				val.GetCtx().Logger,
 				dbm.NewMemDB(),
 				nil,

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.3
 
 replace (
 	// fork wasmd to work with SDK v0.53.4 + IBC v10
-	github.com/CosmWasm/wasmd => github.com/btcq-org/wasmd v0.0.0-20251028132249-8297a11b364e
+	github.com/CosmWasm/wasmd => github.com/btcq-org/wasmd v0.0.0-20260505105426-c1d4060c7271
 	github.com/cometbft/cometbft => github.com/btcq-org/cometbft v0.0.0-20260502040544-c16030e07020
 	github.com/cosmos/cosmos-sdk => github.com/btcq-org/cosmos-sdk v0.0.0-20260502063610-f7f082a54f9f
 	// fix upstream GHSA-h395-qcrw-5vmq vulnerability.

--- a/go.sum
+++ b/go.sum
@@ -276,8 +276,8 @@ github.com/btcq-org/cometbft v0.0.0-20260502040544-c16030e07020 h1:IthHS0E92lU8p
 github.com/btcq-org/cometbft v0.0.0-20260502040544-c16030e07020/go.mod h1:sKSRd02L706oPkbfqZ49hmedh0vGeNj5zedp6AEAx0c=
 github.com/btcq-org/cosmos-sdk v0.0.0-20260502063610-f7f082a54f9f h1:Ab5+DIn5B/QMPaZGR2u2NZnyNfoUpOvxDNAiDT+Hpdo=
 github.com/btcq-org/cosmos-sdk v0.0.0-20260502063610-f7f082a54f9f/go.mod h1:roNjtW5gDpUWbaAKHWF0k+bDPu8pCtEI1st1ppG1zLk=
-github.com/btcq-org/wasmd v0.0.0-20251028132249-8297a11b364e h1:+UD8It+wSKVlRNovOMCwSGIjqMeZCaES41sMr6ivFsM=
-github.com/btcq-org/wasmd v0.0.0-20251028132249-8297a11b364e/go.mod h1:hjhXd6McMd1rDl+QW82VQ6//oPBiLLnXa0Vgj2bIZl8=
+github.com/btcq-org/wasmd v0.0.0-20260505105426-c1d4060c7271 h1:/XbkldafK7TWc7+MH0JgEI0izPQTXJH0/BEi5GMFJ4M=
+github.com/btcq-org/wasmd v0.0.0-20260505105426-c1d4060c7271/go.mod h1:lV0kUfj3IBtGhzp+ksYBePewO17HnnE0U7Z/yTTQsi4=
 github.com/btcsuite/btcd v0.20.1-beta/go.mod h1:wVuoA8VJLEcwgqHBwHmzLRazpKxTv13Px/pDuV7OomQ=
 github.com/btcsuite/btcd v0.22.0-beta.0.20220111032746-97732e52810c/go.mod h1:tjmYdS6MLJ5/s0Fj4DbLgSbDHbEqLJrtnHecBFkdz5M=
 github.com/btcsuite/btcd v0.23.5-0.20231215221805-96c9fd8078fd/go.mod h1:nm3Bko6zh6bWP60UxwoT5LzdGJsQJaPo6HjduXq9p6A=

--- a/tests/e2e/qbtc/cli_test.go
+++ b/tests/e2e/qbtc/cli_test.go
@@ -6,14 +6,14 @@ import (
 	"github.com/cosmos/cosmos-sdk/testutil/network"
 	"github.com/stretchr/testify/suite"
 
-	"github.com/btcq-org/qbtc/app"
+	apptestutil "github.com/btcq-org/qbtc/app/testutil"
 )
 
 // TestE2ETestSuite wires cosmos-sdk's testutil/network harness to our
 // suite. Matches the shape of the SDK's per-module e2e entrypoints
 // (e.g. tests/e2e/bank/cli_test.go).
 func TestE2ETestSuite(t *testing.T) {
-	cfg := network.DefaultConfig(app.NewTestNetworkFixture)
+	cfg := network.DefaultConfig(apptestutil.NewTestNetworkFixture)
 	cfg.NumValidators = 1
 	// Pin the chain ID so proofs minted inside the suite can bind to a
 	// known chain. DefaultConfig otherwise picks a random one.


### PR DESCRIPTION
## Summary

- `app/test_helpers.go` (a non-test file) imported `testutil/network`, which transitively pulled in `github.com/cosmos/cosmos-sdk/x/auth/tx/config`
- That SDK package has its own `init()` that calls `appmodule.Register(&txconfigv1.Config{}, ...)` — the same type `app/config/tx.go` registers for
- `RegisterModule` is last-write-wins (a plain map assignment), so the SDK's `init()` was overwriting the custom registration; depinject called the SDK's `ProvideModule` instead of the custom one, meaning the ebifrost `TxEncoder`/`TxDecoder`/`JSONEncoder`/`JSONDecoder` were never set on `TxConfig`

**Fix:** move `NewTestNetworkFixture` and `testAppOptions` into a new `app/testutil` package (`apptestutil`). This removes `testutil/network` — and by extension `x/auth/tx/config` — from the `app` package's transitive imports entirely. The custom registration in `app/config/tx.go` is now the only registration for `txconfigv1.Config`.

## Test plan

- [ ] `go build ./app/...` passes (verified locally)
- [ ] `go build ./app/testutil/...` and `go build ./tests/e2e/qbtc/...` pass (verified locally)
- [ ] `go list -deps ./app | grep x/auth/tx/config` returns empty — SDK's tx config is no longer in the app's transitive imports (verified locally)
- [ ] Run `make test-unit` to confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CosmWasm/wasmd dependency to a newer version
  * Reorganized test utility package structure

<!-- end of auto-generated comment: release notes by coderabbit.ai -->