### PR TITLE
fix(ante): account_number=0 for fresh claim accounts

### DIFF
--- a/x/qbtc/ebifrost/free_claim_decorator.go
+++ b/x/qbtc/ebifrost/free_claim_decorator.go
@@ -9,13 +9,13 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	authsigning "github.com/cosmos/cosmos-sdk/x/auth/signing"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 )
 
 // AccountKeeper is the subset of x/auth's AccountKeeper the decorator needs to
 // pre-create signer accounts for first-time claimers.
 type AccountKeeper interface {
 	GetAccount(ctx context.Context, addr sdk.AccAddress) sdk.AccountI
-	NewAccountWithAddress(ctx context.Context, addr sdk.AccAddress) sdk.AccountI
 	SetAccount(ctx context.Context, acc sdk.AccountI)
 }
 
@@ -88,11 +88,29 @@ func (fcd FreeClaimDecorator) ensureSignerAccounts(ctx sdk.Context, tx sdk.Tx) e
 	return nil
 }
 
+// createAccountIfMissing pre-creates a BaseAccount for addr if it doesn't
+// already exist. Uses NewBaseAccountWithAddress (account_number = 0) rather
+// than ak.NewAccountWithAddress (auto-increment from the global counter)
+// because wallet-direct claimers cannot predict the auto-assigned number —
+// without a stable account_number they cannot construct a SignDoc the
+// downstream SigVerificationDecorator will accept.
+//
+// account_number=0 is safe here:
+//   - The ZK proof in MsgClaimWithProof binds the claim to (claimer, chain,
+//     version) and is one-shot per UTXO, so it carries the anti-replay
+//     property account_number would otherwise provide for the first tx.
+//   - sequence still increments normally on the persisted BaseAccount,
+//     protecting any subsequent txs from this account.
+//   - The auth store is keyed by address, not by account_number, so
+//     duplicates across fresh claim accounts do not collide.
+//   - The global account-number counter is left untouched; regular
+//     account creations (faucets, transfers, IBC) keep their unique
+//     numbering — they never go through this decorator.
 func (fcd FreeClaimDecorator) createAccountIfMissing(ctx sdk.Context, addr sdk.AccAddress) {
 	if fcd.ak.GetAccount(ctx, addr) != nil {
 		return
 	}
-	fcd.ak.SetAccount(ctx, fcd.ak.NewAccountWithAddress(ctx, addr))
+	fcd.ak.SetAccount(ctx, authtypes.NewBaseAccountWithAddress(addr))
 }
 
 // isClaimOnlyTx returns true if the tx contains only MsgClaimWithProof messages.

--- a/x/qbtc/ebifrost/free_claim_decorator_test.go
+++ b/x/qbtc/ebifrost/free_claim_decorator_test.go
@@ -19,7 +19,6 @@ import (
 // FreeClaimDecorator without spinning up a real keeper.
 type fakeAccountKeeper struct {
 	accounts map[string]sdk.AccountI
-	nextNum  uint64
 }
 
 func newFakeAccountKeeper() *fakeAccountKeeper {
@@ -28,13 +27,6 @@ func newFakeAccountKeeper() *fakeAccountKeeper {
 
 func (f *fakeAccountKeeper) GetAccount(_ context.Context, addr sdk.AccAddress) sdk.AccountI {
 	return f.accounts[addr.String()]
-}
-
-func (f *fakeAccountKeeper) NewAccountWithAddress(_ context.Context, addr sdk.AccAddress) sdk.AccountI {
-	acc := authtypes.NewBaseAccountWithAddress(addr)
-	_ = acc.SetAccountNumber(f.nextNum)
-	f.nextNum++
-	return acc
 }
 
 func (f *fakeAccountKeeper) SetAccount(_ context.Context, acc sdk.AccountI) {
@@ -79,8 +71,13 @@ func TestFreeClaimDecorator_CreatesAccountForFirstTimeClaimer(t *testing.T) {
 
 	require.NoError(t, err)
 	require.True(t, nextCalled, "next decorator should run")
-	require.NotNil(t, ak.GetAccount(context.Background(), claimer),
+	acc := ak.GetAccount(context.Background(), claimer)
+	require.NotNil(t, acc,
 		"claimer account must be pre-created so downstream decorators can look it up")
+	require.Equal(t, uint64(0), acc.GetAccountNumber(),
+		"fresh claim accounts must have account_number=0 so wallet-direct claimers can sign a matching SignDoc")
+	require.Equal(t, uint64(0), acc.GetSequence(),
+		"fresh claim accounts must have sequence=0 so the first claim tx verifies")
 }
 
 func TestFreeClaimDecorator_PreservesExistingAccount(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes #172.

Wallet-direct claimers (fresh address that never used the chain) could not get past `SigVerificationDecorator`. The decorator reads `account_number` from the on-chain account, which was auto-assigned by `NewAccountWithAddress` to whatever the global counter was. The client signed with `account_number = 0` (the only value it can know up-front) and the hashes never matched.

This PR makes the fresh account always have `account_number = 0` so the client and the chain agree on the SignDoc.

## Change

`x/qbtc/ebifrost/free_claim_decorator.go`:

```go
func (fcd FreeClaimDecorator) createAccountIfMissing(ctx sdk.Context, addr sdk.AccAddress) {
    if fcd.ak.GetAccount(ctx, addr) != nil {
        return
    }
    fcd.ak.SetAccount(ctx, authtypes.NewBaseAccountWithAddress(addr))
}
```

I also removed `NewAccountWithAddress` from the local `AccountKeeper` interface since we don't need it anymore.

## Why this is safe

- Claim replay is already protected by the ZK proof. Each UTXO can only be claimed once on chain.
- `sequence` still increments on the BaseAccount, so any next tx from this account is still protected against replay.
- Cosmos stores accounts by address, not by `account_number`. Two accounts with `account_number = 0` don't collide.
- The global account-number counter is not touched here. Regular account creations (faucet, transfer, IBC) keep getting unique numbers.
- `createAccountIfMissing` still returns early when the account already exists, so returning claimers keep their old number.

## Test plan

- [x] `go test ./x/qbtc/ebifrost/...`
- [x] `go build ./...`
- [x] Updated `TestFreeClaimDecorator_CreatesAccountForFirstTimeClaimer` to assert `account_number == 0` and `sequence == 0` on the new account.
- [x] `TestFreeClaimDecorator_PreservesExistingAccount` still passes (existing-account path unchanged).
- [ ] Manual: run the Vultisig claim from a fresh vault and confirm the tx now goes through.

## Downstream

This unblocks the wallet-direct claim flow in:

- vultisig/vultisig-sdk#478 (adds `broadcaster` field to the SDK)
- vultisig/vultisig-windows#3939 (populates `broadcaster` in the windows/extension claim flow)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed account number initialization for first-time claimers using the free claim feature to ensure proper account setup.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/btcq-org/qbtc/pull/173?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->