### PR TITLE
fix(ci): extract go-wrappers before computing LD_LIBRARY_PATH in test-all

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,7 @@ bench:
 
 test-all:
 	@echo Running unit tests...
+	@go mod download github.com/vultisig/go-wrappers
 	@export LD_LIBRARY_PATH=$$(go list -m -f '{{.Dir}}' github.com/vultisig/go-wrappers)/includes/linux:$$LD_LIBRARY_PATH && \
 	go test -mod=readonly -tags=testing -v -timeout 30m ./...
 


### PR DESCRIPTION
## Summary

The `test` job on `main` (which runs `make test-all`) has been failing since the `cmd/dkls-tss` package was added. The failure is a CI module-cache bug, **not** a code bug — `make test-all` passes locally.

The job fails with:

```
dkls-tss.test: error while loading shared libraries: libgodkls.so: cannot open shared object file: No such file or directory
FAIL  github.com/btcq-org/qbtc/cmd/dkls-tss  0.001s
```

### Root cause

`test-all` derives `LD_LIBRARY_PATH` from `go list -m -f '{{.Dir}}' github.com/vultisig/go-wrappers`. The `.Dir` field is **empty when the module zip has not been extracted into the cache yet** (confirmed with a cold-cache test). On a cold CI module cache (the failing run's log shows `go: downloading github.com/vultisig/go-wrappers`), the path resolved to `/includes/linux:`.

The `cmd/dkls-tss` test binary relies entirely on `LD_LIBRARY_PATH` at runtime because go-wrappers' linux cgo directive uses a *relative* rpath (`-Wl,-rpath,../../includes/linux`), which doesn't resolve from the test's working directory. With a bad `LD_LIBRARY_PATH`, `libgodkls.so` can't be found and the job exits non-zero.

Locally it always passes because the module is already extracted in the dev cache.

### Fix

Run `go mod download github.com/vultisig/go-wrappers` before computing the path, forcing extraction so `.Dir` resolves to the real module directory.

## Test plan

- [x] Reproduced the failure locally: `env -u LD_LIBRARY_PATH go test -tags=testing ./cmd/dkls-tss/` → identical `libgodkls.so` error
- [x] Confirmed cold-cache `go list -m -f '{{.Dir}}'` returns empty, and that `go mod download` extracts the module + `.so` files
- [x] Verified the fixed command sequence loads the lib: dkls-tss test binary now starts cleanly
- [ ] CI `test` job on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved test execution workflow to ensure all required dependencies are properly downloaded before test runs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/btcq-org/qbtc/pull/177?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->