### PR TITLE
fix(qbtc): guard nil ScriptPubKey in hasUtxoSendToItself

### DIFF
--- a/x/qbtc/keeper/handler_msg_report_block.go
+++ b/x/qbtc/keeper/handler_msg_report_block.go
@@ -277,6 +277,10 @@ func (s *msgServer) hasUtxoSendToItself(ctx sdk.Context, tx btcjson.TxRawResult)
 		if err != nil {
 			return false, err
 		}
+		if utxo.ScriptPubKey == nil || utxo.ScriptPubKey.Address == "" {
+			// source address unknown, can't confirm the tx is sent to itself
+			return false, nil
+		}
 		sourceAddress = append(sourceAddress, utxo.ScriptPubKey.Address)
 	}
 


### PR DESCRIPTION
## Summary

Fixes the nil-pointer dereference flagged in #180.

`hasUtxoSendToItself` dereferenced `utxo.ScriptPubKey.Address` without a nil guard ([handler_msg_report_block.go:280](https://github.com/btcq-org/qbtc/blob/main/x/qbtc/keeper/handler_msg_report_block.go#L280)). Here `utxo` is our own `types.UTXO`, whose `ScriptPubKey` is a `*ScriptPubKeyResult` proto3 message pointer — **nil when the field is absent in the serialized data**. UTXOs aren't only built by `processVOuts` (which always populates it); they're also loaded from `genState.Utxos` and from chunk files via protobuf deserialization, so a genesis/chunk UTXO that omits the field deserializes to `ScriptPubKey == nil` and panics while processing the proposer-injected `MsgBtcBlock` tx.

This mirrors the guard the claim handler already applies (`handle_msg_claim_with_proof.go:77`).

## Scope

Only this one site is an actual nil-deref. The other `ScriptPubKey` accesses called out in #180 (`processVOuts`, `processCoinbaseVOuts`, `getClaimMemo`, and the vout loop in this same function) operate on `btcjson.Vout.ScriptPubKey`, which is a **value** type and can never be nil — no change needed there.

## Behavior

A missing/empty **source** address is treated as "not sent to itself" (early `return false, nil`), so an input whose address can't be verified is never misclassified as a self-send and can't trigger a spurious claim mint.

## Severity

Bounded, as noted in the issue: `MsgBtcBlock` is proposer-injected and 2/3-attested, so this is robustness / defense-in-depth, not a public attack surface.

## Testing

- `go build ./x/qbtc/keeper/` — passes
- `go test ./x/qbtc/keeper/` — passes

Closes #180

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive design documentation including system architecture diagrams and detailed requirements specification for the smart parking system project.

* **Bug Fixes**
  * Fixed error handling to gracefully manage missing blockchain transaction metadata, preventing validation failures.

* **Chores**
  * Added developer tooling script to bootstrap and initialize local blockchain development environments with automated configuration and dependency verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->