### PR TITLE
fix(qbtc): round BTC-to-satoshi conversion instead of truncating

### DIFF
--- a/bitcoin/indexer.go
+++ b/bitcoin/indexer.go
@@ -207,11 +207,16 @@ func (i *Indexer) ExportUTXO(outPath string) (err error) {
 			continue
 		}
 		fields := strings.Split(string(k), "-")
+		amount, err := qbtctypes.BTCToSatoshis(vOut.Value)
+		if err != nil {
+			// dropping a UTXO would make its coins unclaimable, so abort the export
+			return fmt.Errorf("failed to convert value of utxo %s to satoshis: %w", string(k), err)
+		}
 		pVout := qbtctypes.UTXO{
 			Txid:           fields[0],
 			Vout:           vOut.N,
-			Amount:         uint64(vOut.Value * 1e8), // convert to satoshis
-			EntitledAmount: uint64(vOut.Value * 1e8),
+			Amount:         amount,
+			EntitledAmount: amount,
 			ScriptPubKey: &qbtctypes.ScriptPubKeyResult{
 				Hex:     vOut.ScriptPubKey.Hex,
 				Type:    vOut.ScriptPubKey.Type,

--- a/x/qbtc/keeper/handler_msg_report_block.go
+++ b/x/qbtc/keeper/handler_msg_report_block.go
@@ -177,7 +177,11 @@ func (s *msgServer) processTransaction(ctx sdk.Context, tx btcjson.TxRawResult, 
 		if out.Value == 0 {
 			continue
 		}
-		totalOutput += uint64(out.Value * 1e8)
+		amount, err := types.BTCToSatoshis(out.Value)
+		if err != nil {
+			return fee, fmt.Errorf("fail to convert output value to satoshis: %w", err)
+		}
+		totalOutput += amount
 	}
 	if totalInput > 0 && totalInput > totalOutput {
 		// calculate the transaction fee
@@ -375,16 +379,20 @@ func (s *msgServer) processVOuts(ctx sdk.Context,
 		if out.Value == 0 {
 			continue
 		}
+		amount, err := types.BTCToSatoshis(out.Value)
+		if err != nil {
+			return fmt.Errorf("fail to convert output value to satoshis: %w", err)
+		}
 		// when none of the txout has been claimed before, each utxo can claim the same amount as its value
 		// when any of the txout has been claimed before, each utxo can claim an amount proportional to its value
-		entitleAmount := uint64(out.Value * 1e8)
+		entitleAmount := amount
 		if hasClaim {
-			entitleAmount = totalClaimableAmount * uint64(out.Value*1e8) / totalOutputAmount
+			entitleAmount = totalClaimableAmount * amount / totalOutputAmount
 		}
 		utxo := types.UTXO{
 			Txid:           txID,
 			Vout:           out.N,
-			Amount:         uint64(out.Value * 1e8),
+			Amount:         amount,
 			EntitledAmount: entitleAmount,
 			ScriptPubKey: &types.ScriptPubKeyResult{
 				Hex:     out.ScriptPubKey.Hex,
@@ -411,14 +419,18 @@ func (s *msgServer) processCoinbaseVOuts(ctx sdk.Context,
 			continue
 		}
 
-		entitleAmount := uint64(out.Value * 1e8)
+		amount, err := types.BTCToSatoshis(out.Value)
+		if err != nil {
+			return fmt.Errorf("fail to convert output value to satoshis: %w", err)
+		}
+		entitleAmount := amount
 		if entitleAmount > totalFee {
 			entitleAmount = entitleAmount - totalFee
 		}
 		utxo := types.UTXO{
 			Txid:           txID,
 			Vout:           out.N,
-			Amount:         uint64(out.Value * 1e8),
+			Amount:         amount,
 			EntitledAmount: entitleAmount,
 			ScriptPubKey: &types.ScriptPubKeyResult{
 				Hex:     out.ScriptPubKey.Hex,

--- a/x/qbtc/keeper/handler_msg_report_block_test.go
+++ b/x/qbtc/keeper/handler_msg_report_block_test.go
@@ -80,7 +80,9 @@ func TestSetMsgReportBlock(t *testing.T) {
 				utxo, err := f.keeper.Utxoes.Get(f.ctx, coinbaseKey)
 				require.NoError(st, err)
 				require.NotNil(st, utxo)
-				require.Equal(st, utxo.EntitledAmount, uint64(313461773))
+				// exact fee for this block is 65602 sats; the pre-fix truncating
+				// conversion accumulated 133 extra satoshis of fee
+				require.Equal(st, utxo.EntitledAmount, uint64(313461906))
 
 			},
 		},
@@ -96,7 +98,7 @@ func TestSetMsgReportBlock(t *testing.T) {
 				utxo, err := f.keeper.Utxoes.Get(f.ctx, coinbaseKey)
 				require.NoError(st, err)
 				require.NotNil(st, utxo)
-				require.Equal(st, uint64(2502676488), utxo.EntitledAmount)
+				require.Equal(st, uint64(2502676489), utxo.EntitledAmount)
 
 				key1 := "e8bd07a2b2a68965ef732d6dad74d3af16ac384aff1c92a42e1707f5bc8fb714-0"
 				utxo1, err := f.keeper.Utxoes.Get(f.ctx, key1)
@@ -132,7 +134,7 @@ func TestSetMsgReportBlock(t *testing.T) {
 				utxo, err := f.keeper.Utxoes.Get(f.ctx, coinbaseKey)
 				require.NoError(st, err)
 				require.NotNil(st, utxo)
-				require.Equal(st, uint64(2502666488), utxo.EntitledAmount)
+				require.Equal(st, uint64(2502666489), utxo.EntitledAmount)
 
 				key1 := "2bda3732778da19cbf8799aceed3a6ab270948aeac85678bee013ddf3070687e-0"
 				utxo1, err := f.keeper.Utxoes.Get(f.ctx, key1)
@@ -202,7 +204,7 @@ func TestSetMsgReportBlock(t *testing.T) {
 				utxo, err := f.keeper.Utxoes.Get(f.ctx, coinbaseKey)
 				require.NoError(st, err)
 				require.NotNil(st, utxo)
-				require.Equal(st, uint64(2502666488), utxo.EntitledAmount)
+				require.Equal(st, uint64(2502666489), utxo.EntitledAmount)
 
 				key1 := "bfa3ed4869f33192946dcc03d7789d6be32aa07f083e9752fcea2a5568a9ea47-0"
 				utxo1, err := f.keeper.Utxoes.Get(f.ctx, key1)

--- a/x/qbtc/types/btc_amount.go
+++ b/x/qbtc/types/btc_amount.go
@@ -1,0 +1,23 @@
+package types
+
+import (
+	"fmt"
+
+	"github.com/btcsuite/btcd/btcutil"
+)
+
+// BTCToSatoshis converts a BTC amount decoded from bitcoind JSON to satoshis.
+// The conversion must round to nearest, not truncate: float64 decoding of an
+// 8-decimal BTC string can land just below the exact satoshi value, so
+// uint64(value * 1e8) would be 1 satoshi low. All valid amounts (≤ 21M BTC)
+// are below 2^53 satoshis, so the rounded result is always exact.
+func BTCToSatoshis(value float64) (uint64, error) {
+	amount, err := btcutil.NewAmount(value)
+	if err != nil {
+		return 0, fmt.Errorf("invalid bitcoin amount %v: %w", value, err)
+	}
+	if amount < 0 {
+		return 0, fmt.Errorf("negative bitcoin amount %v", value)
+	}
+	return uint64(amount), nil
+}

--- a/x/qbtc/types/btc_amount_test.go
+++ b/x/qbtc/types/btc_amount_test.go
@@ -1,0 +1,61 @@
+package types_test
+
+import (
+	"math"
+	"strconv"
+	"testing"
+
+	"github.com/btcq-org/qbtc/x/qbtc/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBTCToSatoshis(t *testing.T) {
+	cases := []struct {
+		name string
+		btc  float64
+		want uint64
+	}{
+		{"zero", 0, 0},
+		{"one satoshi", 0.00000001, 1},
+		// 0.00000003 parses to 2.9999...e-8; truncation yields 2 instead of 3
+		{"truncation victim small", 0.00000003, 3},
+		{"truncation victim mid", 0.00000006, 6},
+		{"one btc", 1.0, 1e8},
+		{"max supply", 21_000_000, 2_100_000_000_000_000},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := types.BTCToSatoshis(tc.btc)
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
+		})
+	}
+
+	for name, bad := range map[string]float64{
+		"nan":      math.NaN(),
+		"pos inf":  math.Inf(1),
+		"neg inf":  math.Inf(-1),
+		"negative": -0.5,
+	} {
+		t.Run(name, func(t *testing.T) {
+			_, err := types.BTCToSatoshis(bad)
+			require.Error(t, err)
+		})
+	}
+}
+
+// TestBTCToSatoshisRoundTrip verifies the conversion is exact for every
+// satoshi value in ranges where plain truncation is known to lose 1 satoshi,
+// using the same 8-decimal formatting bitcoind applies before JSON decoding.
+func TestBTCToSatoshisRoundTrip(t *testing.T) {
+	for _, base := range []uint64{1, 100_000, 100_000_000, 2_100_000_000_000_000 - 100_000} {
+		for sat := base; sat < base+100_000; sat++ {
+			s := strconv.FormatFloat(float64(sat)/1e8, 'f', 8, 64)
+			f, err := strconv.ParseFloat(s, 64)
+			require.NoError(t, err)
+			got, err := types.BTCToSatoshis(f)
+			require.NoError(t, err)
+			require.Equal(t, sat, got, "value %s", s)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #181 — `uint64(out.Value * 1e8)` truncates, and float64 decoding of an 8-decimal BTC string frequently lands just below the exact satoshi value. A brute-force scan of 12M satoshi values through the bitcoind format→parse→convert pipeline showed **~8% of amounts truncate 1 satoshi low** (e.g. a 3-sat output records as 2 sats). Truncated outputs also inflate per-tx fees (`fee = totalInput - totalOutput`), which deflates claimable amounts a second time.

## Changes

- New `types.BTCToSatoshis` helper wrapping `btcutil.NewAmount` (round-to-nearest, matching Bitcoin Core; `btcutil` was already a direct dependency). It additionally rejects NaN/±Inf/negative inputs, since this runs in consensus on externally-sourced data. All valid amounts (≤ 21M BTC) are below 2^53 satoshis, so the rounded result is always exact.
- Applied at **all 8 conversion sites** — the 4 listed in the issue, plus 2 more in the handler the issue missed (the proportional-entitlement formula and the coinbase `Amount` field), plus 2 in `bitcoin/indexer.go` (genesis UTXO chunk export, where `Amount`/`EntitledAmount` originate).
- Unit tests for the helper, including known truncation victims (`0.00000003` → 3, not 2) and a 400k-value round-trip test over ranges where truncation is known to fail.

## Fixture updates

Four `TestSetMsgReportBlock` assertions had the truncation bug baked in. I verified each new value independently by replaying the raw block JSON with exact decimal arithmetic:

- block 300003: coinbase entitlement off by 1 sat (truncation inflated the fee from the exact 100000 to 100001) — three assertions.
- block 923828: truncation accumulated **133 extra satoshis** of fee across the block (65735 vs the exact 65602), shorting the coinbase entitlement by the same amount.

## ⚠️ Consensus impact

As flagged in the issue: computed entitlements change, so this must land before mainnet or behind a coordinated upgrade height. Additionally, any **genesis UTXO chunk files generated with the old indexer must be regenerated**, since they carry truncated `Amount`/`EntitledAmount` values.

## Testing

- `go test ./x/qbtc/keeper/ ./x/qbtc/types/ ./bitcoin/` — passes
- full unit test suite (excluding ZK) + `make govet` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved BTC-to-satoshis handling across Bitcoin processing and UTXO export to use a single, validated conversion approach.
  * Conversion failures now halt with clear errors instead of continuing with incorrect arithmetic, improving correctness and reliability of computed amounts.

* **Tests**
  * Added dedicated tests for BTC-to-satoshis conversion (including precision, invalid inputs, and round-trip checks).
  * Updated block reporting assertions to reflect more accurate entitled amount calculations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->