### PR TITLE
fix(install): correct node chain-id to qbtc

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -373,7 +373,7 @@ init_qbtcd() {
 
         if ask_yn "Overwrite existing genesis and data?" "n"; then
             print_info "Running qbtcd init with overwrite..."
-            qbtcd init qbtc-node --home "$QBTCD_HOME" --chain-id bqtbc-testnet --overwrite
+            qbtcd init qbtc-node --home "$QBTCD_HOME" --chain-id qbtc --overwrite
             qbtcd comet unsafe-reset-all --home "$QBTCD_HOME"
         else
             print_info "Skipping qbtcd initialization."
@@ -381,10 +381,10 @@ init_qbtcd() {
         fi
     else
         print_info "Running qbtcd init..."
-        qbtcd init qbtc-node --home "$QBTCD_HOME" --chain-id bqtbc-testnet
+        qbtcd init qbtc-node --home "$QBTCD_HOME" --chain-id qbtc
     fi
 
-    qbtcd config set client chain-id qbtc-testnet --home "$QBTCD_HOME"
+    qbtcd config set client chain-id qbtc --home "$QBTCD_HOME"
     print_info "Downloading genesis.json..."
     if ! curl -fsSL "$GENESIS_URL" -o "$QBTCD_HOME/config/genesis.json"; then
         print_error "Failed to download genesis.json"


### PR DESCRIPTION
## Problem

`scripts/install.sh` uses three inconsistent chain-id values:

| Line | Command | Value |
|---|---|---|
| 376, 384 | `qbtcd init ... --chain-id` | `bqtbc-testnet` (typo) |
| 387 | `qbtcd config set client chain-id` | `qbtc-testnet` |

`bqtbc` is a transposition of `qbtc`. More importantly, the **client config** value (`qbtc-testnet`) does not match the chain operators actually join: the `genesis.json` this script downloads, and the live chain, both report `chain_id = qbtc` (verified via `…/cosmos/base/tendermint/v1beta1/blocks/latest`).

## Impact

The `init` chain-id is cosmetic (the downloaded genesis overrides it), but the **client chain-id mismatch breaks transaction broadcasting** — the SignDoc chain-id must match the node's, so operators currently have to pass `--chain-id qbtc` on every `tx` command or hit a signature-verification error.

## Fix

Align all three to `qbtc`, matching the genesis the script downloads and the running chain.

> Note: if the upcoming mainnet relaunch uses a different chain-id, update this value together with `GENESIS_URL` at that time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the setup flow to initialize and configure the client with the correct `qbtc` chain ID.
  * Preserved the existing overwrite and reset behavior while aligning the generated configuration with the current network name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->