### PR TITLE
feat(qbtc): remove batch size limit for MsgGovClaimUTXO

### DIFF
--- a/x/qbtc/types/msg_gov_claim_utxo.go
+++ b/x/qbtc/types/msg_gov_claim_utxo.go
@@ -13,9 +13,6 @@ func (m *MsgGovClaimUTXO) ValidateBasic() error {
 	if len(m.Utxos) == 0 {
 		return se.ErrInvalidRequest.Wrap("must provide at least one UTXO to claim")
 	}
-	if len(m.Utxos) > MaxBatchClaimUTXOs {
-		return se.ErrInvalidRequest.Wrapf("too many UTXOs in batch: %d (max %d)", len(m.Utxos), MaxBatchClaimUTXOs)
-	}
 	for _, utxo := range m.Utxos {
 		if utxo.Txid == "" {
 			return se.ErrInvalidRequest.Wrap("txid is required")

--- a/x/qbtc/types/msg_gov_claim_utxo_test.go
+++ b/x/qbtc/types/msg_gov_claim_utxo_test.go
@@ -8,9 +8,9 @@ import (
 )
 
 func TestMsgGovClaimUTXO_ValidateBasic(t *testing.T) {
-	oversizedUtxos := make([]*ClaimUTXO, MaxBatchClaimUTXOs+1)
-	for i := range oversizedUtxos {
-		oversizedUtxos[i] = &ClaimUTXO{Txid: "txid", Vout: uint32(i)}
+	largeUtxos := make([]*ClaimUTXO, MaxBatchClaimUTXOs+1)
+	for i := range largeUtxos {
+		largeUtxos[i] = &ClaimUTXO{Txid: "txid", Vout: uint32(i)}
 	}
 
 	tests := []struct {
@@ -22,7 +22,7 @@ func TestMsgGovClaimUTXO_ValidateBasic(t *testing.T) {
 		{name: "no authority", msg: MsgGovClaimUTXO{Utxos: []*ClaimUTXO{{Txid: "txid", Vout: 0}}}, err: se.ErrInvalidRequest.Wrap("authority is required")},
 		{name: "no utxos", msg: MsgGovClaimUTXO{Authority: "btcq1..."}, err: se.ErrInvalidRequest.Wrap("must provide at least one UTXO to claim")},
 		{name: "no txid", msg: MsgGovClaimUTXO{Authority: "btcq1...", Utxos: []*ClaimUTXO{{Vout: 0}}}, err: se.ErrInvalidRequest.Wrap("txid is required")},
-		{name: "too many utxos", msg: MsgGovClaimUTXO{Authority: "btcq1...", Utxos: oversizedUtxos}, err: se.ErrInvalidRequest},
+		{name: "batch size not limited", msg: MsgGovClaimUTXO{Authority: "btcq1...", Utxos: largeUtxos}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary

Removes the `MaxBatchClaimUTXOs` (50) cap from `MsgGovClaimUTXO.ValidateBasic()`. Since this message is governance-authority gated, the batch size limit is unnecessary — governance proposals are trusted and may need to claim larger batches in a single operation.

The limit is preserved for user-submitted `MsgClaimWithProof`, which remains permissionless.

## Changes
- Drop the `len(m.Utxos) > MaxBatchClaimUTXOs` check in [msg_gov_claim_utxo.go](x/qbtc/types/msg_gov_claim_utxo.go)
- Update the test to assert large batches are accepted

## Testing
- `go test ./x/qbtc/types/ -run TestMsgGovClaimUTXO_ValidateBasic` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Larger UTXO claim batches are no longer rejected by basic validation, so valid requests with many items can now proceed.
  * Validation still requires a non-empty authority, at least one UTXO, and a Txid for each UTXO.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->