### PR TITLE
fix(install): bump default version to 1.0.22

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2,7 +2,7 @@
 set -e
 
 # ========== DEFAULTS ==========
-DEFAULT_VERSION="1.0.21"
+DEFAULT_VERSION="1.0.22"
 GITHUB_REPO="btcq-org/qbtc"
 INSTALL_DIR="/usr/local/bin"
 QBTCD_HOME="$HOME/.qbtc"


### PR DESCRIPTION
## Summary
- Bump `DEFAULT_VERSION` in `scripts/install.sh` from `1.0.21` to `1.0.22`.

## Test plan
- N/A — config default value change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the default installed version of the bundled software to `1.0.22` from `1.0.21`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->