### PR TITLE
feat(proof-service): reject invalid signatures before the PLONK prove

### DIFF
--- a/proof-service/prove.go
+++ b/proof-service/prove.go
@@ -3,11 +3,13 @@ package proofservice
 import (
 	"context"
 	"encoding/hex"
+	"errors"
 	"math/big"
 	"net/http"
 
 	"github.com/btcq-org/qbtc/x/qbtc/zk"
 	"github.com/btcsuite/btcd/btcec/v2"
+	btcecdsa "github.com/btcsuite/btcd/btcec/v2/ecdsa"
 )
 
 func (s *Service) generateProof(ctx context.Context, req ProveRequest) (*ProveResponse, int, *ErrorResponse) {
@@ -128,6 +130,18 @@ func (s *Service) generateProof(ctx context.Context, req ProveRequest) (*ProveRe
 	messageHash := zk.ComputeClaimMessage(addressHash, qbtcAddressHash, chainIDHash)
 	s.logger.Info().Str("message_hash", hex.EncodeToString(messageHash[:])).Msg("computed message hash")
 
+	// 8b. Fail fast: verify the ECDSA signature natively (microseconds) before
+	// committing to the ~18s in-circuit prove. The circuit proves this exact
+	// relation, so a signature that does not verify here can never yield a
+	// valid proof; rejecting it now avoids wasting proving capacity.
+	if err := verifyECDSASignature(pubKey, messageHash[:], sigRBytes, sigSBytes); err != nil {
+		return nil, http.StatusBadRequest, &ErrorResponse{
+			Error:   "signature does not verify against the public key and claim message",
+			Code:    "INVALID_SIGNATURE",
+			Details: err.Error(),
+		}
+	}
+
 	// 9. Create prover and generate proof
 	prover := zk.NewProver(s.cs, s.pk)
 
@@ -175,4 +189,28 @@ func (s *Service) generateProof(ctx context.Context, req ProveRequest) (*ProveRe
 	}
 
 	return resp, http.StatusOK, nil
+}
+
+// verifyECDSASignature checks that (r, s) is a valid secp256k1 ECDSA signature
+// of hash under pubKey. rBytes and sBytes must each be 32 bytes. It enforces
+// that r and s are in the valid range [1, n-1] and performs the full native
+// verification, matching what the circuit proves in-circuit.
+func verifyECDSASignature(pubKey *btcec.PublicKey, hash, rBytes, sBytes []byte) error {
+	var r, s btcec.ModNScalar
+	if r.SetByteSlice(rBytes) {
+		return errors.New("signature_r is not less than the curve order")
+	}
+	if s.SetByteSlice(sBytes) {
+		return errors.New("signature_s is not less than the curve order")
+	}
+	if r.IsZero() {
+		return errors.New("signature_r must be non-zero")
+	}
+	if s.IsZero() {
+		return errors.New("signature_s must be non-zero")
+	}
+	if !btcecdsa.NewSignature(&r, &s).Verify(hash, pubKey) {
+		return errors.New("signature verification failed")
+	}
+	return nil
 }

--- a/proof-service/prove_test.go
+++ b/proof-service/prove_test.go
@@ -1,0 +1,89 @@
+package proofservice
+
+import (
+	"crypto/sha256"
+	"testing"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	btcecdsa "github.com/btcsuite/btcd/btcec/v2/ecdsa"
+)
+
+// fixed, non-secret test key
+var testPrivKeyBytes = []byte{
+	0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+	0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xab,
+	0x54, 0xa9, 0x8c, 0xeb, 0x1f, 0x0a, 0xd2, 0x00,
+	0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88,
+}
+
+// signFixture signs hash with the fixed test key and returns the pubkey and the
+// 32-byte big-endian r and s components.
+func signFixture(t *testing.T, hash []byte) (*btcec.PublicKey, []byte, []byte) {
+	t.Helper()
+	priv, pub := btcec.PrivKeyFromBytes(testPrivKeyBytes)
+	sig := btcecdsa.Sign(priv, hash)
+	r := sig.R()
+	s := sig.S()
+	rb := r.Bytes()
+	sb := s.Bytes()
+	return pub, rb[:], sb[:]
+}
+
+func TestVerifyECDSASignature_Valid(t *testing.T) {
+	hash := sha256.Sum256([]byte("claim message"))
+	pub, rb, sb := signFixture(t, hash[:])
+
+	if err := verifyECDSASignature(pub, hash[:], rb, sb); err != nil {
+		t.Fatalf("valid signature rejected: %v", err)
+	}
+}
+
+func TestVerifyECDSASignature_WrongMessage(t *testing.T) {
+	hash := sha256.Sum256([]byte("claim message"))
+	pub, rb, sb := signFixture(t, hash[:])
+
+	other := sha256.Sum256([]byte("different message"))
+	if err := verifyECDSASignature(pub, other[:], rb, sb); err == nil {
+		t.Fatal("expected verification to fail for a different message")
+	}
+}
+
+func TestVerifyECDSASignature_WrongPubKey(t *testing.T) {
+	hash := sha256.Sum256([]byte("claim message"))
+	_, rb, sb := signFixture(t, hash[:])
+
+	// A different key that did not produce the signature.
+	otherBytes := make([]byte, 32)
+	copy(otherBytes, testPrivKeyBytes)
+	otherBytes[31] ^= 0x01
+	_, otherPub := btcec.PrivKeyFromBytes(otherBytes)
+
+	if err := verifyECDSASignature(otherPub, hash[:], rb, sb); err == nil {
+		t.Fatal("expected verification to fail for the wrong public key")
+	}
+}
+
+func TestVerifyECDSASignature_TamperedS(t *testing.T) {
+	hash := sha256.Sum256([]byte("claim message"))
+	pub, rb, sb := signFixture(t, hash[:])
+
+	tampered := make([]byte, len(sb))
+	copy(tampered, sb)
+	tampered[31] ^= 0x01
+	if err := verifyECDSASignature(pub, hash[:], rb, tampered); err == nil {
+		t.Fatal("expected verification to fail for a tampered s value")
+	}
+}
+
+func TestVerifyECDSASignature_ZeroComponents(t *testing.T) {
+	hash := sha256.Sum256([]byte("claim message"))
+	pub, rb, sb := signFixture(t, hash[:])
+	zero := make([]byte, 32)
+
+	if err := verifyECDSASignature(pub, hash[:], zero, sb); err == nil {
+		t.Fatal("expected error for zero r")
+	}
+	if err := verifyECDSASignature(pub, hash[:], rb, zero); err == nil {
+		t.Fatal("expected error for zero s")
+	}
+}


### PR DESCRIPTION
## What

Adds a native secp256k1 ECDSA verification to the `/prove` path, run **before** the ~18s in-circuit PLONK prove. Second of the scoped proof-service hardening PRs (task #5). Independent of #190 (touches only `prove.go`).

## Why

`/prove` currently commits to a full ~18s / ~3GB proof for *any* well-formed request. A signature that is syntactically valid but wrong (or forged) only fails deep inside witness solving after the CPU is already spent. Since the circuit proves exactly the ECDSA relation, the same check done natively takes microseconds and rejects bad input up front — protecting proving capacity from malformed / invalid-signature spam.

## What's in this PR

- `verifyECDSASignature(pubKey, hash, r, s)`: range-checks `r`, `s` to `[1, n-1]` and runs the full native verification against the claim message hash.
- Called in `generateProof` right after the message hash is computed, before the prover runs. Failures return `400 INVALID_SIGNATURE`.

## Measured effect

Live test against a running service (test setup):

| Request | Before | After |
|---|---|---|
| Tampered signature | ~18–20s → error | **7.5ms → 400** |
| Valid signature | ~20s → 200 | ~20s → 200 (unchanged) |

## Testing

`go test ./proof-service/...` — unit tests for `verifyECDSASignature` cover valid, wrong-message, wrong-pubkey, tampered-s, and zero-component cases. Also verified end-to-end against a live service with real (test-SRS) proof generation.

## Follow-ups (remaining task #5 PRs)

- Enforce `request_timeout_sec` / cancellable proving
- Broadcaster per-key sequence tracking (SYNC-mode reuse race)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added an early ECDSA signature verification step before proof generation, rejecting invalid requests faster with an `INVALID_SIGNATURE` error.
  * Strengthened signature validation to handle malformed inputs (including zero/invalid components) and to ensure the signature matches the provided public key and message hash.
* **Tests**
  * Added deterministic tests covering successful verification and multiple failure scenarios (wrong message hash, mismatched public key, tampered signature data, and zeroed signature components).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->