### PR TITLE
chore(install): set consensus timeout parameters in config.toml

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -365,6 +365,26 @@ setup_statesync() {
     print_success "Statesync configured"
 }
 
+configure_consensus_timeouts() {
+    print_header "Configuring consensus timeouts"
+
+    local config_file="$QBTCD_HOME/config/config.toml"
+    if [[ ! -f "$config_file" ]]; then
+        print_error "config.toml not found at $config_file"
+        return 1
+    fi
+
+    print_info "Setting consensus timeout parameters..."
+    sed -i.bak -E \
+        "s|^(timeout_propose[[:space:]]+=[[:space:]]+).*$|\1\"8s\"|
+         s|^(timeout_propose_delta[[:space:]]+=[[:space:]]+).*$|\1\"1s\"|
+         s|^(timeout_prevote[[:space:]]+=[[:space:]]+).*$|\1\"1.5s\"|
+         s|^(timeout_precommit[[:space:]]+=[[:space:]]+).*$|\1\"1.5s\"|" "$config_file"
+    rm -f "${config_file}.bak"
+
+    print_success "Consensus timeouts configured"
+}
+
 init_qbtcd() {
     print_header "Initializing qbtcd"
 
@@ -385,6 +405,9 @@ init_qbtcd() {
     fi
 
     qbtcd config set client chain-id qbtc --home "$QBTCD_HOME"
+
+    configure_consensus_timeouts
+
     print_info "Downloading genesis.json..."
     if ! curl -fsSL "$GENESIS_URL" -o "$QBTCD_HOME/config/genesis.json"; then
         print_error "Failed to download genesis.json"


### PR DESCRIPTION
## Summary

Update `scripts/install.sh` to set consensus timeout parameters in `config.toml` during `qbtcd` initialization:

- `timeout_propose = "8s"`
- `timeout_propose_delta = "1s"`
- `timeout_prevote = "1.5s"`
- `timeout_precommit = "1.5s"`

## Details

Adds a new `configure_consensus_timeouts()` function that patches the `[consensus]` section of `config.toml` using the same `sed` pattern already used by `setup_statesync()`. It's wired into `init_qbtcd()` right after the client chain-id is configured and before genesis download.

## Test plan

- [x] `bash -n scripts/install.sh` passes (syntax check)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved node initialization by automatically applying recommended consensus timing settings as part of the configuration process.

* **Bug Fixes**
  * Added a check to ensure the required configuration file is present before applying updates.
  * Updated configuration safely and now removes temporary backup files after changes to reduce setup issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->